### PR TITLE
Fix toast auto removal

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -10,7 +10,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 5000
 
 // Add this type export
 export type ToastInput = Omit<ToasterToast, "id">;
@@ -187,7 +187,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- shorten toast removal delay
- register toast state listener once to avoid stale updates

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run typecheck` *(fails due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684893b50ef0832aacdf5053020a08bb