### PR TITLE
Add env example and setup doc

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Environment configuration example
+# Rename this file to `.env` and fill in actual values.
+
+# Next.js server port
+PORT=9002
+
+# Genkit development server port
+GENKIT_PORT=4000
+
+# Google Genkit API key for AI features
+GOOGLE_API_KEY=
+
+# Path to Google Cloud service account credentials (optional)
+GOOGLE_APPLICATION_CREDENTIALS=
+

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ next-env.d.ts
 
 .genkit/*
 .env*
+!.env.example
 
 # firebase
 firebase-debug.log

--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ Links from other parts of the application, such as the "Products" listing page (
     # or
     yarn install
     ```
+3.  Copy the example environment file and configure the values:
+    ```bash
+    cp .env.example .env
+    # then edit .env and add your API keys and other settings
+    ```
 
 ### Running the Development Server
 


### PR DESCRIPTION
## Summary
- provide `.env.example` for required configuration
- allow `.env.example` in version control
- document copying `.env.example` to `.env`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: many TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684898deb3ac832aa925783ff7c289aa