### PR TITLE
Add Jest setup with sample test

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Welcome to the Norruva Digital Product Passport (DPP) concept application! This 
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
   - [Running the Development Server](#running-the-development-server)
+  - [Running Tests](#running-tests)
 - [Key Directory Structure](#key-directory-structure)
 - [Firebase Studio Context](#firebase-studio-context)
 
@@ -105,9 +106,19 @@ Links from other parts of the application, such as the "Products" listing page (
     ```bash
     npm run dev
     ```
-    This will start the Next.js application, usually on `http://localhost:9002` (as configured in `package.json`).
+This will start the Next.js application, usually on `http://localhost:9002` (as configured in `package.json`).
 
 Open `http://localhost:9002` in your browser to view the application.
+
+### Running Tests
+
+Run the unit tests with:
+
+```bash
+npm test
+```
+
+Use `npm run test:watch` during development to re-run tests on file changes.
 
 ## Key Directory Structure
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.8.0",
@@ -66,6 +68,9 @@
     "genkit-cli": "^1.8.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@types/jest": "^29.5.7",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/src/utils/__tests__/imageUtils.test.ts
+++ b/src/utils/__tests__/imageUtils.test.ts
@@ -1,0 +1,23 @@
+import { getAiHintForImage } from '../imageUtils';
+
+describe('getAiHintForImage', () => {
+  it('returns the imageHint when provided', () => {
+    const result = getAiHintForImage({ imageHint: 'shiny phone' });
+    expect(result).toBe('shiny phone');
+  });
+
+  it('uses the product name as fallback', () => {
+    const result = getAiHintForImage({ productName: 'Eco-Friendly Water Bottle' });
+    expect(result).toBe('eco-friendly water');
+  });
+
+  it('uses the category if nothing else is available', () => {
+    const result = getAiHintForImage({ category: 'Electronics' });
+    expect(result).toBe('electronics');
+  });
+
+  it('returns a default phrase when no info exists', () => {
+    const result = getAiHintForImage({});
+    expect(result).toBe('product photo');
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest with ts-jest and jsdom
- add test and watch scripts
- provide example test for `getAiHintForImage`
- document how to run the tests

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684898e0cb30832ab208973b42e0854e