### PR TITLE
Remove redundant client directives in utils

### DIFF
--- a/src/utils/aiFormHelpers.tsx
+++ b/src/utils/aiFormHelpers.tsx
@@ -1,7 +1,7 @@
 
 // --- File: aiFormHelpers.tsx ---
 // Description: Utility functions for handling AI-powered suggestions in product forms.
-"use client";
+
 
 import React from "react"; // Added React import for JSX
 import type { UseFormReturn } from "react-hook-form";

--- a/src/utils/apiPlaygroundUtils.ts
+++ b/src/utils/apiPlaygroundUtils.ts
@@ -1,7 +1,7 @@
 
 // --- File: src/utils/apiPlaygroundUtils.ts ---
 // Description: Utility functions for the API Playground in the Developer Portal.
-"use client";
+
 
 export const generateMockCodeSnippet = (
   endpointKey: string,

--- a/src/utils/dppDisplayUtils.tsx
+++ b/src/utils/dppDisplayUtils.tsx
@@ -1,7 +1,7 @@
 
 // --- File: dppDisplayUtils.tsx ---
 // Description: Utility functions for generating display details (text, icons, variants) for DPP compliance, EBSI status, and completeness.
-"use client"; 
+
 
 import React from "react"; 
 import type { DigitalProductPassport, EbsiVerificationDetails, DisplayableProduct, ProductComplianceSummary, SimpleLifecycleEvent } from "@/types/dpp";

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -1,7 +1,7 @@
 
 // --- File: src/utils/fileUtils.ts ---
 // Description: Utility functions for file handling.
-"use client";
+
 
 export const fileToDataUri = (file: File): Promise<string> => {
   return new Promise((resolve, reject) => {

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -1,7 +1,7 @@
 
 // --- File: src/utils/imageUtils.ts ---
 // Description: Utility functions related to image handling and generation.
-"use client";
+
 
 interface ProductImageHintInfo {
   productName?: string | null;

--- a/src/utils/productDetailUtils.ts
+++ b/src/utils/productDetailUtils.ts
@@ -1,7 +1,7 @@
 
 // --- File: src/utils/productDetailUtils.ts ---
 // Description: Utilities for fetching and preparing product details for display.
-"use client";
+
 
 import { USER_PRODUCTS_LOCAL_STORAGE_KEY, MOCK_DPPS } from '@/types/dpp';
 import type { DigitalProductPassport, StoredUserProduct, SimpleProductDetail, ComplianceDetailItem, EbsiVerificationDetails, CustomAttribute, SimpleCertification, Certification } from '@/types/dpp';


### PR DESCRIPTION
## Summary
- delete unused `"use client"` directives from utility modules

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a5fd6fd0832ab0921d2fa33241cd