### PR TITLE
Refactor DPP API reference cards

### DIFF
--- a/src/components/developer/docs/ApiReferenceDppEndpoints.tsx
+++ b/src/components/developer/docs/ApiReferenceDppEndpoints.tsx
@@ -1,7 +1,13 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { FileJson, Server } from "lucide-react";
-import Link from "next/link";
+import { Server } from "lucide-react";
+import {
+  ListDigitalProductPassports,
+  RetrieveDigitalProductPassport,
+  CreateDigitalProductPassport,
+  UpdateDigitalProductPassport,
+  ExtendDigitalProductPassport,
+  AddLifecycleEventToDpp,
+  ArchiveDigitalProductPassport,
+} from "./api-reference";
 
 interface DppEndpointsProps {
   exampleListDppsResponse: string;
@@ -24,475 +30,63 @@ interface DppEndpointsProps {
   error400_lifecycle_event: string;
 }
 
-export default function ApiReferenceDppEndpoints({
-  exampleListDppsResponse,
-  exampleDppResponse,
-  conceptualCreateDppRequestBody,
-  conceptualCreateDppResponseBody,
-  conceptualUpdateDppRequestBody,
-  conceptualUpdateDppResponseBody,
-  conceptualDeleteDppResponseBody,
-  conceptualPatchDppExtendRequestBody,
-  conceptualPatchDppExtendResponseBody,
-  addLifecycleEventRequestBodyExample,
-  addLifecycleEventResponseExample,
-  error401,
-  error404,
-  error500,
-  error400_create_dpp,
-  error400_update_dpp,
-  error400_patch_dpp,
-  error400_lifecycle_event,
-}: DppEndpointsProps) {
+export default function ApiReferenceDppEndpoints(props: DppEndpointsProps) {
   return (
     <section id="dpp-endpoints">
       <h2 className="text-2xl font-semibold font-headline mt-8 mb-4 flex items-center">
-        <Server className="mr-3 h-6 w-6 text-primary" /> Digital Product Passport (DPP) Endpoints
+        <Server className="mr-3 h-6 w-6 text-primary" /> Digital Product
+        Passport (DPP) Endpoints
       </h2>
-
-      <Card className="shadow-lg mt-6">
-        <CardHeader>
-          <CardTitle className="text-lg">List Digital Product Passports</CardTitle>
-          <CardDescription>
-            <span className="inline-flex items-center font-mono text-sm">
-              <Badge variant="outline" className="bg-sky-100 text-sky-700 border-sky-300 mr-2 font-semibold">GET</Badge>
-              <code className="bg-muted px-1 py-0.5 rounded-sm">/dpp</code>
-            </span>
-            <br />
-            Retrieves a list of Digital Product Passports, with optional filtering.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <section>
-            <h4 className="font-semibold mb-1">Query Parameters (Optional)</h4>
-            <ul className="list-disc list-inside text-sm space-y-1">
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">status</code> (string): Filter by DPP status (e.g., "draft", "published", "archived", "pending_review", "revoked", "flagged", "all"). Defaults to "all".</li>
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">category</code> (string): Filter by product category (e.g., "Electronics").</li>
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">searchQuery</code> (string): Search term for product name, ID, GTIN, or manufacturer.</li>
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">blockchainAnchored</code> (string): Filter by blockchain anchoring status ("all", "anchored", "not_anchored"). Defaults to "all".</li>
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">limit</code> (integer, conceptual): Number of items to return per page.</li>
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">offset</code> (integer, conceptual): Number of items to skip for pagination.</li>
-            </ul>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1">Example Response (Success 200 OK)</h4>
-            <p className="text-sm mb-1">Returns a list of DPP objects, applied filters, and total count.</p>
-            <details className="border rounded-md">
-              <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
-                <FileJson className="inline h-4 w-4 mr-1 align-middle" />Example JSON Response
-              </summary>
-              <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
-                <code>{exampleListDppsResponse}</code>
-              </pre>
-            </details>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
-            <ul className="list-disc list-inside text-sm space-y-2">
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">401 Unauthorized</code>: API key missing or invalid.
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error401}</code></pre>
-                </details>
-              </li>
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">500 Internal Server Error</code>: Server-side error.
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error500}</code></pre>
-                </details>
-              </li>
-            </ul>
-          </section>
-        </CardContent>
-      </Card>
-
-      <Card className="shadow-lg mt-6">
-        <CardHeader>
-          <CardTitle className="text-lg">Retrieve a Digital Product Passport</CardTitle>
-          <CardDescription>
-            <span className="inline-flex items-center font-mono text-sm">
-              <Badge variant="outline" className="bg-sky-100 text-sky-700 border-sky-300 mr-2 font-semibold">GET</Badge>
-              <code className="bg-muted px-1 py-0.5 rounded-sm">/dpp/{'{productId}'}</code>
-            </span>
-            <br />
-            Fetches the complete Digital Product Passport for a specific product.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <section>
-            <h4 className="font-semibold mb-1">Path Parameters</h4>
-            <ul className="list-disc list-inside text-sm space-y-1">
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">productId</code> (string, required): The unique identifier of the product.</li>
-            </ul>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1">Example Response (Success 200 OK)</h4>
-            <p className="text-sm mb-1">Returns a DPP object based on the <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">DigitalProductPassport</code> type definition.</p>
-            <details className="border rounded-md">
-              <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
-                <FileJson className="inline h-4 w-4 mr-1 align-middle" />Click to view example JSON response for DPP001
-              </summary>
-              <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
-                <code>{exampleDppResponse}</code>
-              </pre>
-            </details>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
-            <ul className="list-disc list-inside text-sm space-y-2">
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">401 Unauthorized</code>: API key missing or invalid.
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error401}</code></pre>
-                </details>
-              </li>
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">404 Not Found</code>: Product with the given ID does not exist.
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error404}</code></pre>
-                </details>
-              </li>
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">500 Internal Server Error</code>: Server-side error.
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error500}</code></pre>
-                </details>
-              </li>
-            </ul>
-          </section>
-        </CardContent>
-      </Card>
-
-      <Card className="shadow-lg mt-6">
-        <CardHeader>
-          <CardTitle className="text-lg">Create a Digital Product Passport</CardTitle>
-          <CardDescription>
-            <span className="inline-flex items-center font-mono text-sm">
-              <Badge variant="outline" className="bg-green-100 text-green-700 border-green-300 mr-2 font-semibold">POST</Badge>
-              <code className="bg-muted px-1 py-0.5 rounded-sm">/dpp</code>
-            </span>
-            <br />
-            Creates a new Digital Product Passport with the provided initial data.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <section>
-            <h4 className="font-semibold mb-1">Request Body (JSON)</h4>
-            <p className="text-sm mb-1">Provide initial product information. Refer to the <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">CreateDppRequestBody</code> schema in OpenAPI. Required fields typically include <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">productName</code> and <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">category</code>.</p>
-            <details className="border rounded-md">
-              <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
-                <FileJson className="inline h-4 w-4 mr-1 align-middle" />Example JSON Request Body
-              </summary>
-              <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
-                <code>{conceptualCreateDppRequestBody}</code>
-              </pre>
-            </details>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1">Example Response (Success 201 Created)</h4>
-            <p className="text-sm mb-1">Returns the newly created DPP object, including its server-generated ID and default metadata.</p>
-            <details className="border rounded-md">
-              <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
-                <FileJson className="inline h-4 w-4 mr-1 align-middle" />Example JSON Response
-              </summary>
-              <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
-                <code>{conceptualCreateDppResponseBody}</code>
-              </pre>
-            </details>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
-            <ul className="list-disc list-inside text-sm space-y-2">
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">400 Bad Request</code>: Invalid input data (e.g., missing required fields).
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error400_create_dpp}</code></pre>
-                </details>
-              </li>
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">401 Unauthorized</code>.
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error401}</code></pre>
-                </details>
-              </li>
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">500 Internal Server Error</code>.
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error500}</code></pre>
-                </details>
-              </li>
-            </ul>
-          </section>
-        </CardContent>
-      </Card>
-
-      <Card className="shadow-lg mt-6">
-        <CardHeader>
-          <CardTitle className="text-lg">Update a Digital Product Passport</CardTitle>
-          <CardDescription>
-            <span className="inline-flex items-center font-mono text-sm">
-              <Badge variant="outline" className="bg-purple-100 text-purple-700 border-purple-300 mr-2 font-semibold">PUT</Badge>
-              <code className="bg-muted px-1 py-0.5 rounded-sm">/dpp/{'{productId}'}</code>
-            </span>
-            <br />
-            Updates an existing Digital Product Passport. You can send partial or full updates. Unspecified fields will remain unchanged.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <section>
-            <h4 className="font-semibold mb-1">Path Parameters</h4>
-            <ul className="list-disc list-inside text-sm space-y-1">
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">productId</code> (string, required): The unique identifier of the DPP to update.</li>
-            </ul>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1">Request Body (JSON)</h4>
-            <p className="text-sm mb-1">Provide the fields you want to update. Refer to <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">UpdateDppRequestBody</code> schema in OpenAPI.</p>
-            <details className="border rounded-md">
-              <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
-                <FileJson className="inline h-4 w-4 mr-1 align-middle" />Example JSON Request Body (Partial Update)
-              </summary>
-              <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
-                <code>{conceptualUpdateDppRequestBody}</code>
-              </pre>
-            </details>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1">Example Response (Success 200 OK)</h4>
-            <p className="text-sm mb-1">Returns the complete, updated DPP object.</p>
-            <details className="border rounded-md">
-              <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
-                <FileJson className="inline h-4 w-4 mr-1 align-middle" />Example JSON Response
-              </summary>
-              <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
-                <code>{conceptualUpdateDppResponseBody}</code>
-              </pre>
-            </details>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
-            <ul className="list-disc list-inside text-sm space-y-2">
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">400 Bad Request</code>: Invalid input data (e.g., invalid field values).
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error400_update_dpp}</code></pre>
-                </details>
-              </li>
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">401 Unauthorized</code>.
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error401}</code></pre>
-                </details>
-              </li>
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">404 Not Found</code>: DPP with the given ID does not exist.
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error404}</code></pre>
-                </details>
-              </li>
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">500 Internal Server Error</code>.
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error500}</code></pre>
-                </details>
-              </li>
-            </ul>
-          </section>
-        </CardContent>
-      </Card>
-
-      <Card className="shadow-lg mt-6">
-        <CardHeader>
-          <CardTitle className="text-lg">Extend a Digital Product Passport</CardTitle>
-          <CardDescription>
-            <span className="inline-flex items-center font-mono text-sm">
-              <Badge variant="outline" className="bg-orange-100 text-orange-700 border-orange-300 mr-2 font-semibold">PATCH</Badge>
-              <code className="bg-muted px-1 py-0.5 rounded-sm">/dpp/extend/{'{productId}'}</code>
-            </span>
-            <br />
-            Allows for extending a DPP by adding document references or other modular data.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <section>
-            <h4 className="font-semibold mb-1">Path Parameters</h4>
-            <ul className="list-disc list-inside text-sm space-y-1">
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">productId</code> (string, required): The unique identifier of the DPP to extend.</li>
-            </ul>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1">Request Body (JSON)</h4>
-            <p className="text-sm mb-1">Example: Adding a document reference. See OpenAPI spec for other extendable modules (e.g., conceptual chainOfCustodyUpdate).</p>
-            <details className="border rounded-md">
-              <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
-                <FileJson className="inline h-4 w-4 mr-1 align-middle" />Example JSON Request Body (Add Document)
-              </summary>
-              <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
-                <code>{conceptualPatchDppExtendRequestBody}</code>
-              </pre>
-            </details>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1">Example Response (Success 200 OK)</h4>
-            <p className="text-sm mb-1">Returns the complete, updated DPP object with the new data added.</p>
-            <details className="border rounded-md">
-              <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
-                <FileJson className="inline h-4 w-4 mr-1 align-middle" />Example JSON Response (Document Added)
-              </summary>
-              <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
-                <code>{conceptualPatchDppExtendResponseBody}</code>
-              </pre>
-            </details>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
-            <ul className="list-disc list-inside text-sm space-y-2">
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">400 Bad Request</code>: Invalid input data (e.g., missing fields for documentReference).
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error400_patch_dpp}</code></pre>
-                </details>
-              </li>
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">401 Unauthorized</code>. (Example in GET /dpp/{'{id}'})</li>
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">404 Not Found</code>. (Example in GET /dpp/{'{id}'})</li>
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">500 Internal Server Error</code>. (Example in GET /dpp/{'{id}'})</li>
-            </ul>
-          </section>
-        </CardContent>
-      </Card>
-
-      <Card className="shadow-lg mt-6">
-        <CardHeader>
-          <CardTitle className="text-lg">Add Lifecycle Event to DPP</CardTitle>
-          <CardDescription>
-            <span className="inline-flex items-center font-mono text-sm">
-              <Badge variant="outline" className="bg-green-100 text-green-700 border-green-300 mr-2 font-semibold">POST</Badge>
-              <code className="bg-muted px-1 py-0.5 rounded-sm">/dpp/{'{productId}'}/lifecycle-events</code>
-            </span>
-            <br />
-            Adds a new lifecycle event to the specified Digital Product Passport.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <section>
-            <h4 className="font-semibold mb-1">Path Parameters</h4>
-            <ul className="list-disc list-inside text-sm space-y-1">
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">productId</code> (string, required): The unique identifier of the product.</li>
-            </ul>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1">Request Body (JSON)</h4>
-            <p className="text-sm mb-1">Provide details for the lifecycle event. 'eventType' is required.</p>
-            <details className="border rounded-md">
-              <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
-                <FileJson className="inline h-4 w-4 mr-1 align-middle" />Example JSON Request Body
-              </summary>
-              <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
-                <code>{addLifecycleEventRequestBodyExample}</code>
-              </pre>
-            </details>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1">Example Response (Success 201 Created)</h4>
-            <p className="text-sm mb-1">Returns the newly created LifecycleEvent object.</p>
-            <details className="border rounded-md">
-              <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
-                <FileJson className="inline h-4 w-4 mr-1 align-middle" />Example JSON Response
-              </summary>
-              <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
-                <code>{addLifecycleEventResponseExample}</code>
-              </pre>
-            </details>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
-            <ul className="list-disc list-inside text-sm space-y-2">
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">400 Bad Request</code>: Invalid input data (e.g., missing 'eventType').
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error400_lifecycle_event}</code></pre>
-                </details>
-              </li>
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">401 Unauthorized</code>. (See example under GET /dpp/{'{id}'})</li>
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">404 Not Found</code>. (See example under GET /dpp/{'{id}'})</li>
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">500 Internal Server Error</code>. (See example under GET /dpp/{'{id}'})</li>
-            </ul>
-          </section>
-        </CardContent>
-      </Card>
-
-      <Card className="shadow-lg mt-6">
-        <CardHeader>
-          <CardTitle className="text-lg">Archive a Digital Product Passport</CardTitle>
-          <CardDescription>
-            <span className="inline-flex items-center font-mono text-sm">
-              <Badge variant="outline" className="bg-red-100 text-red-700 border-red-300 mr-2 font-semibold">DELETE</Badge>
-              <code className="bg-muted px-1 py-0.5 rounded-sm">/dpp/{'{productId}'}</code>
-            </span>
-            <br />
-            Archives an existing Digital Product Passport by setting its status to 'archived'. This is a soft delete.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <section>
-            <h4 className="font-semibold mb-1">Path Parameters</h4>
-            <ul className="list-disc list-inside text-sm space-y-1">
-              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">productId</code> (string, required): The unique identifier of the DPP to archive.</li>
-            </ul>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1">Example Response (Success 200 OK)</h4>
-            <details className="border rounded-md">
-              <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
-                <FileJson className="inline h-4 w-4 mr-1 align-middle" />Example JSON Response
-              </summary>
-              <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
-                <code>{conceptualDeleteDppResponseBody}</code>
-              </pre>
-            </details>
-          </section>
-          <section>
-            <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
-            <ul className="list-disc list-inside text-sm space-y-2">
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">401 Unauthorized</code>.
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error401}</code></pre>
-                </details>
-              </li>
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">404 Not Found</code>: DPP with the given ID does not exist.
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error404}</code></pre>
-                </details>
-              </li>
-              <li>
-                <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">500 Internal Server Error</code>.
-                <details className="border rounded-md mt-1">
-                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
-                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error500}</code></pre>
-                </details>
-              </li>
-            </ul>
-          </section>
-        </CardContent>
-      </Card>
+      <ListDigitalProductPassports
+        exampleListDppsResponse={props.exampleListDppsResponse}
+        error401={props.error401}
+        error500={props.error500}
+      />
+      <RetrieveDigitalProductPassport
+        exampleDppResponse={props.exampleDppResponse}
+        error401={props.error401}
+        error404={props.error404}
+        error500={props.error500}
+      />
+      <CreateDigitalProductPassport
+        conceptualCreateDppRequestBody={props.conceptualCreateDppRequestBody}
+        conceptualCreateDppResponseBody={props.conceptualCreateDppResponseBody}
+        error400_create_dpp={props.error400_create_dpp}
+        error401={props.error401}
+        error500={props.error500}
+      />
+      <UpdateDigitalProductPassport
+        conceptualUpdateDppRequestBody={props.conceptualUpdateDppRequestBody}
+        conceptualUpdateDppResponseBody={props.conceptualUpdateDppResponseBody}
+        error400_update_dpp={props.error400_update_dpp}
+        error401={props.error401}
+        error404={props.error404}
+        error500={props.error500}
+      />
+      <ExtendDigitalProductPassport
+        conceptualPatchDppExtendRequestBody={
+          props.conceptualPatchDppExtendRequestBody
+        }
+        conceptualPatchDppExtendResponseBody={
+          props.conceptualPatchDppExtendResponseBody
+        }
+        error400_patch_dpp={props.error400_patch_dpp}
+      />
+      <AddLifecycleEventToDpp
+        addLifecycleEventRequestBodyExample={
+          props.addLifecycleEventRequestBodyExample
+        }
+        addLifecycleEventResponseExample={
+          props.addLifecycleEventResponseExample
+        }
+        error400_lifecycle_event={props.error400_lifecycle_event}
+      />
+      <ArchiveDigitalProductPassport
+        conceptualDeleteDppResponseBody={props.conceptualDeleteDppResponseBody}
+        error401={props.error401}
+        error404={props.error404}
+        error500={props.error500}
+      />
     </section>
   );
 }

--- a/src/components/developer/docs/api-reference/AddLifecycleEventToDpp.tsx
+++ b/src/components/developer/docs/api-reference/AddLifecycleEventToDpp.tsx
@@ -1,0 +1,126 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { FileJson } from "lucide-react";
+
+interface AddLifecycleEventToDppProps {
+  addLifecycleEventRequestBodyExample: string;
+  addLifecycleEventResponseExample: string;
+  error400_lifecycle_event: string;
+}
+
+export default function AddLifecycleEventToDpp({
+  addLifecycleEventRequestBodyExample,
+  addLifecycleEventResponseExample,
+  error400_lifecycle_event,
+}: AddLifecycleEventToDppProps) {
+  return (
+    <Card className="shadow-lg mt-6">
+      <CardHeader>
+        <CardTitle className="text-lg">Add Lifecycle Event to DPP</CardTitle>
+        <CardDescription>
+          <span className="inline-flex items-center font-mono text-sm">
+            <Badge
+              variant="outline"
+              className="bg-green-100 text-green-700 border-green-300 mr-2 font-semibold"
+            >
+              POST
+            </Badge>
+            <code className="bg-muted px-1 py-0.5 rounded-sm">
+              /dpp/{"{productId}"}/lifecycle-events
+            </code>
+          </span>
+          <br />
+          Adds a new lifecycle event to the specified Digital Product Passport.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <section>
+          <h4 className="font-semibold mb-1">Path Parameters</h4>
+          <ul className="list-disc list-inside text-sm space-y-1">
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                productId
+              </code>{" "}
+              (string, required): The unique identifier of the product.
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1">Request Body (JSON)</h4>
+          <p className="text-sm mb-1">
+            Provide details for the lifecycle event. 'eventType' is required.
+          </p>
+          <details className="border rounded-md">
+            <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
+              <FileJson className="inline h-4 w-4 mr-1 align-middle" />
+              Example JSON Request Body
+            </summary>
+            <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
+              <code>{addLifecycleEventRequestBodyExample}</code>
+            </pre>
+          </details>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1">
+            Example Response (Success 201 Created)
+          </h4>
+          <p className="text-sm mb-1">
+            Returns the newly created LifecycleEvent object.
+          </p>
+          <details className="border rounded-md">
+            <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
+              <FileJson className="inline h-4 w-4 mr-1 align-middle" />
+              Example JSON Response
+            </summary>
+            <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
+              <code>{addLifecycleEventResponseExample}</code>
+            </pre>
+          </details>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
+          <ul className="list-disc list-inside text-sm space-y-2">
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                400 Bad Request
+              </code>
+              : Invalid input data (e.g., missing 'eventType').
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error400_lifecycle_event}</code>
+                </pre>
+              </details>
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                401 Unauthorized
+              </code>
+              . (See example under GET /dpp/{"{id}"})
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                404 Not Found
+              </code>
+              . (See example under GET /dpp/{"{id}"})
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                500 Internal Server Error
+              </code>
+              . (See example under GET /dpp/{"{id}"})
+            </li>
+          </ul>
+        </section>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/developer/docs/api-reference/ArchiveDigitalProductPassport.tsx
+++ b/src/components/developer/docs/api-reference/ArchiveDigitalProductPassport.tsx
@@ -1,0 +1,123 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { FileJson } from "lucide-react";
+
+interface ArchiveDigitalProductPassportProps {
+  conceptualDeleteDppResponseBody: string;
+  error401: string;
+  error404: string;
+  error500: string;
+}
+
+export default function ArchiveDigitalProductPassport({
+  conceptualDeleteDppResponseBody,
+  error401,
+  error404,
+  error500,
+}: ArchiveDigitalProductPassportProps) {
+  return (
+    <Card className="shadow-lg mt-6">
+      <CardHeader>
+        <CardTitle className="text-lg">
+          Archive a Digital Product Passport
+        </CardTitle>
+        <CardDescription>
+          <span className="inline-flex items-center font-mono text-sm">
+            <Badge
+              variant="outline"
+              className="bg-red-100 text-red-700 border-red-300 mr-2 font-semibold"
+            >
+              DELETE
+            </Badge>
+            <code className="bg-muted px-1 py-0.5 rounded-sm">
+              /dpp/{"{productId}"}
+            </code>
+          </span>
+          <br />
+          Archives an existing Digital Product Passport by setting its status to
+          'archived'. This is a soft delete.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <section>
+          <h4 className="font-semibold mb-1">Path Parameters</h4>
+          <ul className="list-disc list-inside text-sm space-y-1">
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                productId
+              </code>{" "}
+              (string, required): The unique identifier of the DPP to archive.
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1">
+            Example Response (Success 200 OK)
+          </h4>
+          <details className="border rounded-md">
+            <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
+              <FileJson className="inline h-4 w-4 mr-1 align-middle" />
+              Example JSON Response
+            </summary>
+            <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
+              <code>{conceptualDeleteDppResponseBody}</code>
+            </pre>
+          </details>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
+          <ul className="list-disc list-inside text-sm space-y-2">
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                401 Unauthorized
+              </code>
+              .
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error401}</code>
+                </pre>
+              </details>
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                404 Not Found
+              </code>
+              : DPP with the given ID does not exist.
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error404}</code>
+                </pre>
+              </details>
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                500 Internal Server Error
+              </code>
+              .
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error500}</code>
+                </pre>
+              </details>
+            </li>
+          </ul>
+        </section>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/developer/docs/api-reference/CreateDigitalProductPassport.tsx
+++ b/src/components/developer/docs/api-reference/CreateDigitalProductPassport.tsx
@@ -1,0 +1,142 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { FileJson } from "lucide-react";
+
+interface CreateDigitalProductPassportProps {
+  conceptualCreateDppRequestBody: string;
+  conceptualCreateDppResponseBody: string;
+  error400_create_dpp: string;
+  error401: string;
+  error500: string;
+}
+
+export default function CreateDigitalProductPassport({
+  conceptualCreateDppRequestBody,
+  conceptualCreateDppResponseBody,
+  error400_create_dpp,
+  error401,
+  error500,
+}: CreateDigitalProductPassportProps) {
+  return (
+    <Card className="shadow-lg mt-6">
+      <CardHeader>
+        <CardTitle className="text-lg">
+          Create a Digital Product Passport
+        </CardTitle>
+        <CardDescription>
+          <span className="inline-flex items-center font-mono text-sm">
+            <Badge
+              variant="outline"
+              className="bg-green-100 text-green-700 border-green-300 mr-2 font-semibold"
+            >
+              POST
+            </Badge>
+            <code className="bg-muted px-1 py-0.5 rounded-sm">/dpp</code>
+          </span>
+          <br />
+          Creates a new Digital Product Passport with the provided initial data.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <section>
+          <h4 className="font-semibold mb-1">Request Body (JSON)</h4>
+          <p className="text-sm mb-1">
+            Provide initial product information. Refer to the{" "}
+            <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+              CreateDppRequestBody
+            </code>{" "}
+            schema in OpenAPI. Required fields typically include{" "}
+            <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+              productName
+            </code>{" "}
+            and{" "}
+            <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+              category
+            </code>
+            .
+          </p>
+          <details className="border rounded-md">
+            <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
+              <FileJson className="inline h-4 w-4 mr-1 align-middle" />
+              Example JSON Request Body
+            </summary>
+            <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
+              <code>{conceptualCreateDppRequestBody}</code>
+            </pre>
+          </details>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1">
+            Example Response (Success 201 Created)
+          </h4>
+          <p className="text-sm mb-1">
+            Returns the newly created DPP object, including its server-generated
+            ID and default metadata.
+          </p>
+          <details className="border rounded-md">
+            <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
+              <FileJson className="inline h-4 w-4 mr-1 align-middle" />
+              Example JSON Response
+            </summary>
+            <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
+              <code>{conceptualCreateDppResponseBody}</code>
+            </pre>
+          </details>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
+          <ul className="list-disc list-inside text-sm space-y-2">
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                400 Bad Request
+              </code>
+              : Invalid input data (e.g., missing required fields).
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error400_create_dpp}</code>
+                </pre>
+              </details>
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                401 Unauthorized
+              </code>
+              .
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error401}</code>
+                </pre>
+              </details>
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                500 Internal Server Error
+              </code>
+              .
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error500}</code>
+                </pre>
+              </details>
+            </li>
+          </ul>
+        </section>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/developer/docs/api-reference/ExtendDigitalProductPassport.tsx
+++ b/src/components/developer/docs/api-reference/ExtendDigitalProductPassport.tsx
@@ -1,0 +1,130 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { FileJson } from "lucide-react";
+
+interface ExtendDigitalProductPassportProps {
+  conceptualPatchDppExtendRequestBody: string;
+  conceptualPatchDppExtendResponseBody: string;
+  error400_patch_dpp: string;
+}
+
+export default function ExtendDigitalProductPassport({
+  conceptualPatchDppExtendRequestBody,
+  conceptualPatchDppExtendResponseBody,
+  error400_patch_dpp,
+}: ExtendDigitalProductPassportProps) {
+  return (
+    <Card className="shadow-lg mt-6">
+      <CardHeader>
+        <CardTitle className="text-lg">
+          Extend a Digital Product Passport
+        </CardTitle>
+        <CardDescription>
+          <span className="inline-flex items-center font-mono text-sm">
+            <Badge
+              variant="outline"
+              className="bg-orange-100 text-orange-700 border-orange-300 mr-2 font-semibold"
+            >
+              PATCH
+            </Badge>
+            <code className="bg-muted px-1 py-0.5 rounded-sm">
+              /dpp/extend/{"{productId}"}
+            </code>
+          </span>
+          <br />
+          Allows for extending a DPP by adding document references or other
+          modular data.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <section>
+          <h4 className="font-semibold mb-1">Path Parameters</h4>
+          <ul className="list-disc list-inside text-sm space-y-1">
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                productId
+              </code>{" "}
+              (string, required): The unique identifier of the DPP to extend.
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1">Request Body (JSON)</h4>
+          <p className="text-sm mb-1">
+            Example: Adding a document reference. See OpenAPI spec for other
+            extendable modules (e.g., conceptual chainOfCustodyUpdate).
+          </p>
+          <details className="border rounded-md">
+            <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
+              <FileJson className="inline h-4 w-4 mr-1 align-middle" />
+              Example JSON Request Body (Add Document)
+            </summary>
+            <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
+              <code>{conceptualPatchDppExtendRequestBody}</code>
+            </pre>
+          </details>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1">
+            Example Response (Success 200 OK)
+          </h4>
+          <p className="text-sm mb-1">
+            Returns the complete, updated DPP object with the new data added.
+          </p>
+          <details className="border rounded-md">
+            <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
+              <FileJson className="inline h-4 w-4 mr-1 align-middle" />
+              Example JSON Response (Document Added)
+            </summary>
+            <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
+              <code>{conceptualPatchDppExtendResponseBody}</code>
+            </pre>
+          </details>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
+          <ul className="list-disc list-inside text-sm space-y-2">
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                400 Bad Request
+              </code>
+              : Invalid input data (e.g., missing fields for documentReference).
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error400_patch_dpp}</code>
+                </pre>
+              </details>
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                401 Unauthorized
+              </code>
+              . (Example in GET /dpp/{"{id}"})
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                404 Not Found
+              </code>
+              . (Example in GET /dpp/{"{id}"})
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                500 Internal Server Error
+              </code>
+              . (Example in GET /dpp/{"{id}"})
+            </li>
+          </ul>
+        </section>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/developer/docs/api-reference/ListDigitalProductPassports.tsx
+++ b/src/components/developer/docs/api-reference/ListDigitalProductPassports.tsx
@@ -1,0 +1,141 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { FileJson } from "lucide-react";
+
+interface ListDigitalProductPassportsProps {
+  exampleListDppsResponse: string;
+  error401: string;
+  error500: string;
+}
+
+export default function ListDigitalProductPassports({
+  exampleListDppsResponse,
+  error401,
+  error500,
+}: ListDigitalProductPassportsProps) {
+  return (
+    <Card className="shadow-lg mt-6">
+      <CardHeader>
+        <CardTitle className="text-lg">
+          List Digital Product Passports
+        </CardTitle>
+        <CardDescription>
+          <span className="inline-flex items-center font-mono text-sm">
+            <Badge
+              variant="outline"
+              className="bg-sky-100 text-sky-700 border-sky-300 mr-2 font-semibold"
+            >
+              GET
+            </Badge>
+            <code className="bg-muted px-1 py-0.5 rounded-sm">/dpp</code>
+          </span>
+          <br />
+          Retrieves a list of Digital Product Passports, with optional
+          filtering.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <section>
+          <h4 className="font-semibold mb-1">Query Parameters (Optional)</h4>
+          <ul className="list-disc list-inside text-sm space-y-1">
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                status
+              </code>{" "}
+              (string): Filter by DPP status (e.g., "draft", "published",
+              "archived", "pending_review", "revoked", "flagged", "all").
+              Defaults to "all".
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                category
+              </code>{" "}
+              (string): Filter by product category (e.g., "Electronics").
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                searchQuery
+              </code>{" "}
+              (string): Search term for product name, ID, GTIN, or manufacturer.
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                blockchainAnchored
+              </code>{" "}
+              (string): Filter by blockchain anchoring status ("all",
+              "anchored", "not_anchored"). Defaults to "all".
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                limit
+              </code>{" "}
+              (integer, conceptual): Number of items to return per page.
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                offset
+              </code>{" "}
+              (integer, conceptual): Number of items to skip for pagination.
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1">
+            Example Response (Success 200 OK)
+          </h4>
+          <p className="text-sm mb-1">
+            Returns a list of DPP objects, applied filters, and total count.
+          </p>
+          <details className="border rounded-md">
+            <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
+              <FileJson className="inline h-4 w-4 mr-1 align-middle" />
+              Example JSON Response
+            </summary>
+            <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
+              <code>{exampleListDppsResponse}</code>
+            </pre>
+          </details>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
+          <ul className="list-disc list-inside text-sm space-y-2">
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                401 Unauthorized
+              </code>
+              : API key missing or invalid.
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error401}</code>
+                </pre>
+              </details>
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                500 Internal Server Error
+              </code>
+              : Server-side error.
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error500}</code>
+                </pre>
+              </details>
+            </li>
+          </ul>
+        </section>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/developer/docs/api-reference/RetrieveDigitalProductPassport.tsx
+++ b/src/components/developer/docs/api-reference/RetrieveDigitalProductPassport.tsx
@@ -1,0 +1,129 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { FileJson } from "lucide-react";
+
+interface RetrieveDigitalProductPassportProps {
+  exampleDppResponse: string;
+  error401: string;
+  error404: string;
+  error500: string;
+}
+
+export default function RetrieveDigitalProductPassport({
+  exampleDppResponse,
+  error401,
+  error404,
+  error500,
+}: RetrieveDigitalProductPassportProps) {
+  return (
+    <Card className="shadow-lg mt-6">
+      <CardHeader>
+        <CardTitle className="text-lg">
+          Retrieve a Digital Product Passport
+        </CardTitle>
+        <CardDescription>
+          <span className="inline-flex items-center font-mono text-sm">
+            <Badge
+              variant="outline"
+              className="bg-sky-100 text-sky-700 border-sky-300 mr-2 font-semibold"
+            >
+              GET
+            </Badge>
+            <code className="bg-muted px-1 py-0.5 rounded-sm">
+              /dpp/{"{productId}"}
+            </code>
+          </span>
+          <br />
+          Fetches the complete Digital Product Passport for a specific product.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <section>
+          <h4 className="font-semibold mb-1">Path Parameters</h4>
+          <ul className="list-disc list-inside text-sm space-y-1">
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                productId
+              </code>{" "}
+              (string, required): The unique identifier of the product.
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1">
+            Example Response (Success 200 OK)
+          </h4>
+          <p className="text-sm mb-1">
+            Returns a DPP object based on the{" "}
+            <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+              DigitalProductPassport
+            </code>{" "}
+            type definition.
+          </p>
+          <details className="border rounded-md">
+            <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
+              <FileJson className="inline h-4 w-4 mr-1 align-middle" />
+              Click to view example JSON response for DPP001
+            </summary>
+            <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
+              <code>{exampleDppResponse}</code>
+            </pre>
+          </details>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
+          <ul className="list-disc list-inside text-sm space-y-2">
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                401 Unauthorized
+              </code>
+              : API key missing or invalid.
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error401}</code>
+                </pre>
+              </details>
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                404 Not Found
+              </code>
+              : Product with the given ID does not exist.
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error404}</code>
+                </pre>
+              </details>
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                500 Internal Server Error
+              </code>
+              : Server-side error.
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error500}</code>
+                </pre>
+              </details>
+            </li>
+          </ul>
+        </section>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/developer/docs/api-reference/UpdateDigitalProductPassport.tsx
+++ b/src/components/developer/docs/api-reference/UpdateDigitalProductPassport.tsx
@@ -1,0 +1,163 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { FileJson } from "lucide-react";
+
+interface UpdateDigitalProductPassportProps {
+  conceptualUpdateDppRequestBody: string;
+  conceptualUpdateDppResponseBody: string;
+  error400_update_dpp: string;
+  error401: string;
+  error404: string;
+  error500: string;
+}
+
+export default function UpdateDigitalProductPassport({
+  conceptualUpdateDppRequestBody,
+  conceptualUpdateDppResponseBody,
+  error400_update_dpp,
+  error401,
+  error404,
+  error500,
+}: UpdateDigitalProductPassportProps) {
+  return (
+    <Card className="shadow-lg mt-6">
+      <CardHeader>
+        <CardTitle className="text-lg">
+          Update a Digital Product Passport
+        </CardTitle>
+        <CardDescription>
+          <span className="inline-flex items-center font-mono text-sm">
+            <Badge
+              variant="outline"
+              className="bg-purple-100 text-purple-700 border-purple-300 mr-2 font-semibold"
+            >
+              PUT
+            </Badge>
+            <code className="bg-muted px-1 py-0.5 rounded-sm">
+              /dpp/{"{productId}"}
+            </code>
+          </span>
+          <br />
+          Updates an existing Digital Product Passport. You can send partial or
+          full updates. Unspecified fields will remain unchanged.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <section>
+          <h4 className="font-semibold mb-1">Path Parameters</h4>
+          <ul className="list-disc list-inside text-sm space-y-1">
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                productId
+              </code>{" "}
+              (string, required): The unique identifier of the DPP to update.
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1">Request Body (JSON)</h4>
+          <p className="text-sm mb-1">
+            Provide the fields you want to update. Refer to{" "}
+            <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+              UpdateDppRequestBody
+            </code>{" "}
+            schema in OpenAPI.
+          </p>
+          <details className="border rounded-md">
+            <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
+              <FileJson className="inline h-4 w-4 mr-1 align-middle" />
+              Example JSON Request Body (Partial Update)
+            </summary>
+            <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
+              <code>{conceptualUpdateDppRequestBody}</code>
+            </pre>
+          </details>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1">
+            Example Response (Success 200 OK)
+          </h4>
+          <p className="text-sm mb-1">
+            Returns the complete, updated DPP object.
+          </p>
+          <details className="border rounded-md">
+            <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
+              <FileJson className="inline h-4 w-4 mr-1 align-middle" />
+              Example JSON Response
+            </summary>
+            <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
+              <code>{conceptualUpdateDppResponseBody}</code>
+            </pre>
+          </details>
+        </section>
+        <section>
+          <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
+          <ul className="list-disc list-inside text-sm space-y-2">
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                400 Bad Request
+              </code>
+              : Invalid input data (e.g., invalid field values).
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error400_update_dpp}</code>
+                </pre>
+              </details>
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                401 Unauthorized
+              </code>
+              .
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error401}</code>
+                </pre>
+              </details>
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                404 Not Found
+              </code>
+              : DPP with the given ID does not exist.
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error404}</code>
+                </pre>
+              </details>
+            </li>
+            <li>
+              <code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">
+                500 Internal Server Error
+              </code>
+              .
+              <details className="border rounded-md mt-1">
+                <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">
+                  Example JSON
+                </summary>
+                <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4">
+                  <code>{error500}</code>
+                </pre>
+              </details>
+            </li>
+          </ul>
+        </section>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/developer/docs/api-reference/index.ts
+++ b/src/components/developer/docs/api-reference/index.ts
@@ -1,0 +1,7 @@
+export { default as ListDigitalProductPassports } from './ListDigitalProductPassports';
+export { default as RetrieveDigitalProductPassport } from './RetrieveDigitalProductPassport';
+export { default as CreateDigitalProductPassport } from './CreateDigitalProductPassport';
+export { default as UpdateDigitalProductPassport } from './UpdateDigitalProductPassport';
+export { default as ExtendDigitalProductPassport } from './ExtendDigitalProductPassport';
+export { default as AddLifecycleEventToDpp } from './AddLifecycleEventToDpp';
+export { default as ArchiveDigitalProductPassport } from './ArchiveDigitalProductPassport';


### PR DESCRIPTION
## Summary
- split each DPP API endpoint into its own component under `api-reference/`
- simplify `ApiReferenceDppEndpoints` to compose new components
- export endpoint components via an index file

## Testing
- `npm run typecheck` *(fails: Cannot find modules and types)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a98119cc832aac09a7aa0e9739ee