### PR TITLE
Add API playground code snippet tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,6 @@ module.exports = {
   testEnvironment: 'jsdom',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1'
-  }
+  },
+  testMatch: ['**/__tests__/**/*.ts']
 };

--- a/src/utils/__tests__/apiPlaygroundUtils.test.ts
+++ b/src/utils/__tests__/apiPlaygroundUtils.test.ts
@@ -1,0 +1,27 @@
+import { generateMockCodeSnippet } from '../apiPlaygroundUtils';
+
+describe('generateMockCodeSnippet', () => {
+  it('generates cURL snippet', () => {
+    const result = generateMockCodeSnippet('getProduct', 'GET', 'cURL', { productId: '123' }, null, 'dev');
+    expect(result).toBe("curl -X GET \\\n  '/api/v1/dpp/123' \\\n  -H 'Authorization: Bearer YOUR_DEV_API_KEY'");
+  });
+
+  it('generates JavaScript snippet', () => {
+    const result = generateMockCodeSnippet('createDpp', 'POST', 'JavaScript', {}, '{"name":"foo"}', 'prod');
+    expect(result).toBe(
+      "fetch('/api/v1/dpp', {\n  method: 'POST',\n  headers: {\n    'Authorization': 'Bearer YOUR_PROD_API_KEY',\n    'Content-Type': 'application/json'\n  },\n  body: JSON.stringify({\"name\":\"foo\"})\n})\n.then(response => response.json())\n.then(data => console.log(data))\n.catch(error => console.error('Error:', error));"
+    );
+  });
+
+  it('generates Python snippet', () => {
+    const result = generateMockCodeSnippet('updateDpp', 'PUT', 'Python', { productId: 'abc' }, '{"hi":"there"}', 'prod');
+    expect(result).toBe(
+      "import requests\nimport json\n\nurl = \"/api/v1/dpp/abc\"\nheaders = {\n  \"Authorization\": \"Bearer YOUR_PROD_API_KEY\",\n  \"Content-Type\": \"application/json\"\n}\npayload = json.loads(\"\"\"{\"hi\":\"there\"}\"\"\")\nresponse = requests.request(\"PUT\", url, headers=headers, json=payload)\n\nprint(response.json())"
+    );
+  });
+
+  it('handles unsupported language', () => {
+    const result = generateMockCodeSnippet('getProduct', 'GET', 'Ruby', { productId: '123' }, null, 'dev');
+    expect(result).toBe('Code snippet not available for this language.');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest tests for `generateMockCodeSnippet`
- update Jest config to look for `__tests__` folders

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a983a718832ab3161217773f5135