### PR TITLE
Update Globe to use viewport state for sizing

### DIFF
--- a/src/app/(app)/dpp-global-tracker/page.tsx
+++ b/src/app/(app)/dpp-global-tracker/page.tsx
@@ -85,6 +85,8 @@ export default function DppGlobalTrackerPage() {
   const [selectedInfo, setSelectedInfo] = useState<SelectedInfo>({ type: null, data: null });
   const [globeReady, setGlobeReady] = useState(false);
   const [initialLoadComplete, setInitialLoadComplete] = useState(false);
+  const [viewportWidth, setViewportWidth] = useState(600);
+  const [viewportHeight, setViewportHeight] = useState(400);
 
 
   useEffect(() => {
@@ -108,6 +110,18 @@ export default function DppGlobalTrackerPage() {
       globeEl.current.pointOfView({ lat: 20, lng: 0, altitude: 3.0 }, 1500);
     }
   }, [globeReady]);
+
+  useEffect(() => {
+    const updateViewport = () => {
+      if (typeof window !== 'undefined') {
+        setViewportWidth(window.innerWidth);
+        setViewportHeight(window.innerHeight - 64);
+      }
+    };
+    updateViewport();
+    window.addEventListener('resize', updateViewport);
+    return () => window.removeEventListener('resize', updateViewport);
+  }, []);
 
   const handlePointClick = useCallback((point: object) => {
     const p = point as PointData;
@@ -179,8 +193,8 @@ export default function DppGlobalTrackerPage() {
         polygonStrokeColor={() => 'rgba(120,120,120,0.2)'}
         
         onGlobeReady={() => setTimeout(() => setGlobeReady(true), 200)} // Slight delay for full init
-        width={typeof window !== 'undefined' ? window.innerWidth : 600}
-        height={typeof window !== 'undefined' ? window.innerHeight - 64 : 400} // Adjust height if needed
+        width={viewportWidth}
+        height={viewportHeight} // Adjust height if needed
       />
 
       {selectedInfo.data && (


### PR DESCRIPTION
## Summary
- track viewport size with state in the DPP Global Tracker page
- update `Globe` width and height props to use viewport state

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848afdc2a04832a92d16831ed329528