### PR TITLE
Add ARIA live region for toast announcements

### DIFF
--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -15,20 +15,22 @@ export function Toaster() {
 
   return (
     <ToastProvider>
-      {toasts.map(function ({ id, title, description, action, ...props }) {
-        return (
-          <Toast key={id} {...props}>
-            <div className="grid gap-1">
-              {title && <ToastTitle>{title}</ToastTitle>}
-              {description && (
-                <ToastDescription>{description}</ToastDescription>
-              )}
-            </div>
-            {action}
-            <ToastClose />
-          </Toast>
-        )
-      })}
+      <div role="status" aria-live="polite">
+        {toasts.map(function ({ id, title, description, action, ...props }) {
+          return (
+            <Toast key={id} {...props}>
+              <div className="grid gap-1">
+                {title && <ToastTitle>{title}</ToastTitle>}
+                {description && (
+                  <ToastDescription>{description}</ToastDescription>
+                )}
+              </div>
+              {action}
+              <ToastClose />
+            </Toast>
+          )
+        })}
+      </div>
       <ToastViewport />
     </ToastProvider>
   )


### PR DESCRIPTION
## Summary
- wrap toast list in a `<div role="status" aria-live="polite">` so screen readers announce new toasts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b8468828832ab1a75b6c8ff12def