### PR TITLE
Implement debounced search

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ As of the current version, the following key areas and features have been protot
     - Listing existing products.
     - Adding new products via manual entry or AI-assisted document extraction.
     - Viewing detailed product information on the individual product detail page.
+    - Debounced search filtering for smoother performance on large datasets.
 - **AI Compliance Co-Pilot:** An AI assistant to answer questions about EU DPP regulations.
 - **Compliance Pathways:** Step-by-step guidance for specific regulations (e.g., EU Battery Regulation).
 - **GDPR Management Page:** Mock interface for consent and data subject rights.
@@ -68,6 +69,12 @@ As of the current version, the following key areas and features have been protot
     - Linking suppliers to products (viewable on the product detail page's "Supply Chain" tab).
 - **Developer Portal:** Mock portal with API key management, interactive playground, and conceptual documentation.
 - **Settings Page:** Basic user profile, notifications, and organization settings.
+
+## Performance Considerations
+
+Search filtering inputs now use a debounced update to avoid unnecessary renders.
+For very large DPP lists, implementing server-side pagination is recommended and
+profiling should be done with realistic datasets.
 
 ## Product Detail Page
 

--- a/src/components/dpp-dashboard/DashboardFiltersComponent.tsx
+++ b/src/components/dpp-dashboard/DashboardFiltersComponent.tsx
@@ -5,6 +5,8 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
+import { useState, useEffect } from "react";
+import useDebounce from "@/hooks/useDebounce";
 import type { DashboardFiltersState } from "@/types/dpp";
 import { Filter, ListFilter, Search, Link as LinkIcon, SlidersHorizontal, XCircle } from "lucide-react";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
@@ -32,6 +34,17 @@ export const DashboardFiltersComponent: React.FC<DashboardFiltersComponentProps>
   availableRegulations,
   availableCategories,
 }) => {
+  const [searchValue, setSearchValue] = useState(filters.searchQuery);
+  const debouncedSearch = useDebounce(searchValue, 300);
+
+  useEffect(() => {
+    setSearchValue(filters.searchQuery);
+  }, [filters.searchQuery]);
+
+  useEffect(() => {
+    onFiltersChange({ searchQuery: debouncedSearch });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch]);
   const statusOptions = [
     { value: "all", label: "All Statuses" },
     { value: "draft", label: "Draft" },
@@ -90,8 +103,8 @@ export const DashboardFiltersComponent: React.FC<DashboardFiltersComponentProps>
                     id="search-query"
                     type="text"
                     placeholder="Enter product name..."
-                    value={filters.searchQuery || ""}
-                    onChange={(e) => onFiltersChange({ searchQuery: e.target.value })}
+                    value={searchValue}
+                    onChange={(e) => setSearchValue(e.target.value)}
                     className="w-full"
                   />
                 </div>

--- a/src/components/products/ProductManagementFiltersComponent.tsx
+++ b/src/components/products/ProductManagementFiltersComponent.tsx
@@ -5,6 +5,8 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
+import { useState, useEffect } from "react";
+import useDebounce from "@/hooks/useDebounce";
 import { Filter, ListFilter, Search, Tag, ShieldAlert, CheckSquare, Link as LinkIcon, XCircle } from "lucide-react"; // Added XCircle
 import { Button } from "@/components/ui/button"; // Added Button import
 
@@ -39,9 +41,24 @@ export default function ProductManagementFiltersComponent({
   complianceOptions,
   categoryOptions,
 }: ProductManagementFiltersComponentProps) {
+  const [searchValue, setSearchValue] = useState(filters.searchQuery);
+  const debouncedSearch = useDebounce(searchValue, 300);
+
+  useEffect(() => {
+    setSearchValue(filters.searchQuery);
+  }, [filters.searchQuery]);
+
+  useEffect(() => {
+    onFilterChange({ ...filters, searchQuery: debouncedSearch });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch]);
 
   const handleInputChange = (filterName: keyof ProductManagementFilterState, value: string) => {
-    onFilterChange({ ...filters, [filterName]: value });
+    if (filterName === 'searchQuery') {
+      setSearchValue(value);
+    } else {
+      onFilterChange({ ...filters, [filterName]: value });
+    }
   };
 
   const anchoringOptions = [
@@ -74,7 +91,7 @@ export default function ProductManagementFiltersComponent({
               id="search-query"
               type="text"
               placeholder="Enter search term..."
-              value={filters.searchQuery}
+              value={searchValue}
               onChange={(e) => handleInputChange('searchQuery', e.target.value)}
               className="w-full"
             />

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react';
+
+export default function useDebounce<T>(value: T, delay = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Summary
- add a `useDebounce` hook
- defer search filtering in product management filters
- defer search filtering in dashboard filters
- document debounced search and performance tips

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b8471850832a8bd83e896e6e27e6