### PR TITLE
Audit Image priority usage

### DIFF
--- a/src/components/products/detail/OverviewTab.tsx
+++ b/src/components/products/detail/OverviewTab.tsx
@@ -54,7 +54,6 @@ export default function OverviewTab({ product }: OverviewTabProps) {
                 fill // Use fill for AspectRatio
                 className="object-contain" // object-contain to ensure full image is visible
                 data-ai-hint={aiHint}
-                priority={!imageDisplayUrl.startsWith("data:")} // Avoid priority for Data URIs
               />
             </AspectRatio>
           </CardHeader>

--- a/src/components/products/form/ProductImageFormSection.tsx
+++ b/src/components/products/form/ProductImageFormSection.tsx
@@ -86,7 +86,6 @@ export default function ProductImageFormSection({
                 fill
                 className="object-contain rounded"
                 data-ai-hint={imageHintForDataAttr}
-                priority={!currentImageUrl.startsWith("data:")}
               />
             </AspectRatio>
             {(form.getValues("imageUrlOrigin") === 'AI_EXTRACTED' || (initialImageUrlOrigin === 'AI_EXTRACTED' && form.getValues("imageUrl") === initialImageUrl)) && (


### PR DESCRIPTION
## Summary
- remove `priority` from non-essential product images
- keep `priority` only for core images like `Logo` and hero product image

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails due to missing dependencies)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b84aa800832a8b2298bb4f606787