### PR TITLE
Add Space Grotesk headlines

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,7 +3,16 @@
 @tailwind utilities;
 
 body {
-  font-family: 'Inter', sans-serif; /* Updated default body font */
+  @apply font-body;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  @apply font-headline;
 }
 
 @layer base {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,8 +18,13 @@ export default function RootLayout({
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        {/* Inter is already included, Space Grotesk is removed as per new typography guidelines for general text. Logo might still use it. */}
+        <link
+          rel="preload"
+          as="style"
+          href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap"
+        />
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+        <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
       </head>
       <body className="font-body antialiased">
         <RoleProvider> {/* RoleProvider now wraps all children at the root level */}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,7 +11,7 @@ export default {
     extend: {
       fontFamily: {
         body: ['Inter', 'sans-serif'],
-        headline: ['Inter', 'sans-serif'], // Updated to Inter as per guidelines
+        headline: ['Space Grotesk', 'sans-serif'],
         code: ['monospace'],
       },
       colors: {


### PR DESCRIPTION
## Summary
- use Space Grotesk for headline font
- preload Space Grotesk in the main layout
- make headings use `font-headline`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ba9c071c832aafcb4fa0663f6235