### PR TITLE
Add semantic text utilities

### DIFF
--- a/src/app/(app)/compliance/pathways/battery-regulation/page.tsx
+++ b/src/app/(app)/compliance/pathways/battery-regulation/page.tsx
@@ -150,7 +150,7 @@ export default function BatteryRegulationPathwayPage() {
                     title: 'Mock Submission Successful!',
                     description: 'Your EU Battery Regulation Pathway data has been conceptually submitted. The wizard will now reset.',
                     duration: 7000,
-                    action: <CheckCircle className="text-green-500" />,
+                    action: <CheckCircle className="text-success" />,
                   });
                   setActiveStep(euBatteryRegulationSteps[0].id);
                 }}

--- a/src/app/(app)/compliance/pathways/espr/page.tsx
+++ b/src/app/(app)/compliance/pathways/espr/page.tsx
@@ -333,7 +333,7 @@ export default function EsprPathwayPage() {
                             title: "Mock ESPR Submission Successful!",
                             description: "Your ESPR Pathway data has been conceptually submitted. The wizard will now reset.",
                             duration: 7000,
-                            action: <CheckCircle className="text-green-500" />
+                            action: <CheckCircle className="text-success" />
                         });
                         setActiveStep(esprPathwaySteps[0].id);
                         // Reset form data if needed

--- a/src/app/(app)/customs-dashboard/page.tsx
+++ b/src/app/(app)/customs-dashboard/page.tsx
@@ -46,10 +46,10 @@ const MetricCardWidget: React.FC<{title: string, value: string | number, icon: R
 
   if (trendDirection === "up") {
     TrendIconComponent = ArrowUp;
-    trendColor = "text-green-500";
+    trendColor = "text-success";
   } else if (trendDirection === "down") {
     TrendIconComponent = ArrowDown;
-    trendColor = "text-red-500";
+    trendColor = "text-danger";
   }
 
   return (

--- a/src/app/(app)/developer/page.tsx
+++ b/src/app/(app)/developer/page.tsx
@@ -64,20 +64,20 @@ const platformAnnouncements = [
 ];
 
 const DataFlowKPIs = [
-    { title: "DPP Creation Success Rate", value: "99.8%", icon: CheckCircle, color: "text-green-500", description: "Successful DPP initial creations via API." },
+    { title: "DPP Creation Success Rate", value: "99.8%", icon: CheckCircle, color: "text-success", description: "Successful DPP initial creations via API." },
     { title: "Average Data Ingestion Time", value: "1.2s", icon: Clock, color: "text-blue-500", description: "Time from API call to DPP visibility." },
     { title: "DPP Retrieval Speed (P95)", value: "250ms", icon: ZapIcon, color: "text-info", description: "95th percentile for public API GET /dpp/{id}." },
-    { title: "Webhook Delivery Success", value: "99.95%", icon: Send, color: "text-green-500", description: "Successful event notifications to subscribed endpoints." },
+    { title: "Webhook Delivery Success", value: "99.95%", icon: Send, color: "text-success", description: "Successful event notifications to subscribed endpoints." },
 ];
 
 const systemStatusData = [
-    { name: "DPP Core API", status: "Operational", icon: CheckCircle, color: "text-green-500" },
-    { name: "AI Services (Genkit Flows)", status: "Operational", icon: CheckCircle, color: "text-green-500" },
-    { name: "Data Extraction Service (Mock)", status: "Degraded Performance", icon: AlertTriangle, color: "text-yellow-500" },
-    { name: "EBSI Mock Interface", status: "Operational", icon: CheckCircle, color: "text-green-500" },
-    { name: "Developer Portal Site", status: "Operational", icon: CheckCircle, color: "text-green-500" },
+    { name: "DPP Core API", status: "Operational", icon: CheckCircle, color: "text-success" },
+    { name: "AI Services (Genkit Flows)", status: "Operational", icon: CheckCircle, color: "text-success" },
+    { name: "Data Extraction Service (Mock)", status: "Degraded Performance", icon: AlertTriangle, color: "text-warning" },
+    { name: "EBSI Mock Interface", status: "Operational", icon: CheckCircle, color: "text-success" },
+    { name: "Developer Portal Site", status: "Operational", icon: CheckCircle, color: "text-success" },
     { name: "Sandbox Environment API", status: "Under Maintenance", icon: Wrench, color: "text-blue-500" },
-    { name: "Documentation Site", status: "Operational", icon: CheckCircle, color: "text-green-500" },
+    { name: "Documentation Site", status: "Operational", icon: CheckCircle, color: "text-success" },
 ];
 
 const dashboardQuickActions = [
@@ -379,12 +379,12 @@ export default function DeveloperPortalPage() {
   const overallSystemStatus = useMemo(() => {
     const nonOperationalServices = systemStatusData.filter(s => s.status !== "Operational");
     if (nonOperationalServices.length === 0) {
-      return { text: "All Systems Operational", icon: CheckCircle, color: "text-green-500" };
+      return { text: "All Systems Operational", icon: CheckCircle, color: "text-success" };
     }
     if (nonOperationalServices.some(s => s.status === "Degraded Performance" || s.status === "Under Maintenance")) {
-      return { text: "Some Systems Impacted", icon: AlertTriangle, color: "text-yellow-500" };
+      return { text: "Some Systems Impacted", icon: AlertTriangle, color: "text-warning" };
     }
-    return { text: "Multiple Issues Detected", icon: ServerCrash, color: "text-red-500" };
+    return { text: "Multiple Issues Detected", icon: ServerCrash, color: "text-danger" };
   }, []);
 
   const handleRefreshStatus = () => {

--- a/src/app/(app)/dpp-global-tracker/page.tsx
+++ b/src/app/(app)/dpp-global-tracker/page.tsx
@@ -65,7 +65,7 @@ const PointIcon = ({ type }: { type: PointData['type'] }) => {
   switch (type) {
     case 'port': return <Anchor className="h-4 w-4 mr-2 text-blue-500" />;
     case 'factory': return <Factory className="h-4 w-4 mr-2 text-orange-500" />;
-    case 'market': return <Store className="h-4 w-4 mr-2 text-green-500" />;
+    case 'market': return <Store className="h-4 w-4 mr-2 text-success" />;
     case 'dpp_registration': return <Zap className="h-4 w-4 mr-2 text-purple-500" />;
     default: return <MapPin className="h-4 w-4 mr-2 text-gray-500" />;
   }
@@ -73,7 +73,7 @@ const PointIcon = ({ type }: { type: PointData['type'] }) => {
 
 const ArcIcon = ({ status }: { status?: ArcData['status'] }) => {
     if (status === 'in_transit') return <Truck className="h-4 w-4 mr-2 text-blue-500" />;
-    if (status === 'delivered') return <CheckCircleIcon className="h-4 w-4 mr-2 text-green-500" />;
+    if (status === 'delivered') return <CheckCircleIcon className="h-4 w-4 mr-2 text-success" />;
     if (status === 'delayed') return <ClockIcon className="h-4 w-4 mr-2 text-orange-500" />;
     return <Plane className="h-4 w-4 mr-2 text-gray-500" />;
 };
@@ -224,7 +224,7 @@ export default function DppGlobalTrackerPage() {
                 <p className="capitalize"><strong className="text-muted-foreground text-xs">Status:</strong> {(selectedInfo.data as ArcData).status?.replace('_', ' ') || 'N/A'}</p>
                 <p className="text-xs"><strong className="text-muted-foreground text-xs">Route:</strong> {(mockPoints.find(p => p.lat === (selectedInfo.data as ArcData).startLat && p.lng === (selectedInfo.data as ArcData).startLng)?.name || 'Unknown Origin')} &rarr; {(mockPoints.find(p => p.lat === (selectedInfo.data as ArcData).endLat && p.lng === (selectedInfo.data as ArcData).endLng)?.name || 'Unknown Destination')}</p>
                 {(selectedInfo.data as ArcData).status === 'in_transit' && <p className="text-xs text-blue-500 dark:text-blue-400 mt-1">ETA: 3 days</p>}
-                {(selectedInfo.data as ArcData).status === 'delivered' && <p className="text-xs text-green-500 dark:text-green-400 mt-1">Delivered on Schedule.</p>}
+                {(selectedInfo.data as ArcData).status === 'delivered' && <p className="text-xs text-success mt-1">Delivered on Schedule.</p>}
                 {(selectedInfo.data as ArcData).status === 'delayed' && <p className="text-xs text-orange-500 dark:text-orange-400 mt-1">Delayed by 24h due to customs.</p>}
               </>
             )}
@@ -237,7 +237,7 @@ export default function DppGlobalTrackerPage() {
         <div className="mt-2 opacity-90 text-xs leading-tight flex justify-center items-center gap-x-3 gap-y-1 flex-wrap">
             <span className="inline-flex items-center"><Anchor className="h-3 w-3 mr-1 text-blue-500"/>Ports</span>
             <span className="inline-flex items-center"><Factory className="h-3 w-3 mr-1 text-orange-500"/>Factories</span>
-            <span className="inline-flex items-center"><Store className="h-3 w-3 mr-1 text-green-500"/>Markets</span>
+            <span className="inline-flex items-center"><Store className="h-3 w-3 mr-1 text-success"/>Markets</span>
             <span className="inline-flex items-center"><Zap className="h-3 w-3 mr-1 text-purple-500"/>DPP Hotspots</span>
         </div>
       </div>

--- a/src/app/(app)/gdpr/page.tsx
+++ b/src/app/(app)/gdpr/page.tsx
@@ -40,7 +40,7 @@ export default function GdprPage() {
     toast({
       title: "Consent Settings Saved",
       description: "Your consent preferences have been updated successfully.",
-      action: <CheckCircle className="text-green-500" />,
+      action: <CheckCircle className="text-success" />,
     });
   };
 

--- a/src/app/(app)/products/new/page.tsx
+++ b/src/app/(app)/products/new/page.tsx
@@ -166,7 +166,7 @@ export default function AddNewProductPage() {
         description: "Information has been extracted from your document. Please review and complete the details in the 'Manual Entry / Review' tab. Fields populated by AI are marked.",
         variant: "default",
         duration: 7000,
-        action: <CheckCircle2 className="text-green-500" />,
+        action: <CheckCircle2 className="text-success" />,
       });
       setActiveTab("manual");
     } catch (err) {
@@ -207,7 +207,7 @@ export default function AddNewProductPage() {
             ...productCoreData, 
           };
           localStorage.setItem(USER_PRODUCTS_LOCAL_STORAGE_KEY, JSON.stringify(userProducts));
-          toast({ title: "Product Updated", description: `${productCoreData.productName} has been updated.`, variant: "default", action: <CheckCircle2 className="text-green-500" /> });
+          toast({ title: "Product Updated", description: `${productCoreData.productName} has been updated.`, variant: "default", action: <CheckCircle2 className="text-success" /> });
           router.push(`/products/${editProductId}`);
         } else {
           throw new Error("Product not found for update.");
@@ -215,7 +215,7 @@ export default function AddNewProductPage() {
       } else {
         userProducts.push(productCoreData);
         localStorage.setItem(USER_PRODUCTS_LOCAL_STORAGE_KEY, JSON.stringify(userProducts));
-        toast({ title: "Product Saved", description: `${productCoreData.productName} has been saved.`, variant: "default", action: <CheckCircle2 className="text-green-500" /> });
+        toast({ title: "Product Saved", description: `${productCoreData.productName} has been saved.`, variant: "default", action: <CheckCircle2 className="text-success" /> });
         router.push('/products');
       }
 

--- a/src/app/(app)/sustainability/page.tsx
+++ b/src/app/(app)/sustainability/page.tsx
@@ -162,7 +162,7 @@ export default function SustainabilityPage() {
       <div className="grid md:grid-cols-2 gap-6">
         <Card className="shadow-lg">
           <CardHeader>
-            <CardTitle className="font-headline flex items-center"><Zap className="mr-3 h-6 w-6 text-yellow-500" /> Energy Consumption</CardTitle>
+            <CardTitle className="font-headline flex items-center"><Zap className="mr-3 h-6 w-6 text-warning" /> Energy Consumption</CardTitle>
             <CardDescription>Overview of energy usage and efficiency metrics.</CardDescription>
           </CardHeader>
           <CardContent>
@@ -176,7 +176,7 @@ export default function SustainabilityPage() {
 
         <Card className="shadow-lg">
           <CardHeader>
-            <CardTitle className="font-headline flex items-center"><Leaf className="mr-3 h-6 w-6 text-green-500" /> Environmental Impact</CardTitle>
+            <CardTitle className="font-headline flex items-center"><Leaf className="mr-3 h-6 w-6 text-success" /> Environmental Impact</CardTitle>
             <CardDescription>Other key environmental impact metrics.</CardDescription>
           </CardHeader>
           <CardContent>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -126,3 +126,14 @@ body {
     @apply bg-background text-foreground;
   }
 }
+@layer utilities {
+  .text-success {
+    color: hsl(var(--accent));
+  }
+  .text-warning {
+    color: hsl(var(--warning));
+  }
+  .text-danger {
+    color: hsl(var(--destructive));
+  }
+}

--- a/src/app/passport/[passportId]/page.tsx
+++ b/src/app/passport/[passportId]/page.tsx
@@ -267,7 +267,7 @@ export default function PublicPassportPage({ params }: Props) {
                           <div className="flex justify-between items-center">
                             <span className="font-medium">{cert.name}</span>
                             {cert.isVerified && (
-                                <ShieldCheck className="h-4 w-4 text-green-500" title="Verified Certification" />
+                                <ShieldCheck className="h-4 w-4 text-success" title="Verified Certification" />
                             )}
                           </div>
                           <p className="text-xs text-muted-foreground mt-0.5">Authority: {cert.authority}</p>

--- a/src/components/dashboard/PlatformHealthStatsCard.tsx
+++ b/src/components/dashboard/PlatformHealthStatsCard.tsx
@@ -8,7 +8,7 @@ export const PlatformHealthStatsCard = () => {
     { title: "API Call Volume (24h)", value: "1.2M", icon: Activity, trend: "+5%", trendDirection: "up" as const },
     { title: "Active User Sessions", value: "345", icon: Users, trend: "-2%", trendDirection: "down" as const },
     { title: "DPP Verification Queue", value: "17", icon: FileClock, trend: "+3", trendDirection: "up" as const },
-    { title: "Database Performance", value: "Optimal", icon: Database, statusColor: "text-green-500" },
+    { title: "Database Performance", value: "Optimal", icon: Database, statusColor: "text-success" },
     { title: "AI Model Requests (24h)", value: "5,670", icon: Cpu, trend: "+10%", trendDirection: "up" as const },
     { title: "Storage Utilization", value: "65%", icon: HardDrive, trend: "+1%", trendDirection: "up" as const },
   ];
@@ -32,7 +32,7 @@ export const PlatformHealthStatsCard = () => {
             <div className="flex items-center">
               <span className={`text-sm font-semibold ${stat.statusColor || ''}`}>{stat.value}</span>
               {stat.trend && (
-                <span className={`ml-2 text-xs ${stat.trendDirection === 'up' ? 'text-green-500' : 'text-red-500'}`}>
+                <span className={`ml-2 text-xs ${stat.trendDirection === 'up' ? 'text-success' : 'text-danger'}`}>
                   ({stat.trend})
                 </span>
               )}

--- a/src/components/developer/dashboard/ServiceStatusCard.tsx
+++ b/src/components/developer/dashboard/ServiceStatusCard.tsx
@@ -54,9 +54,9 @@ export default function ServiceStatusCard({
       </CardHeader>
       <CardContent className="space-y-3">
         <div className={cn("p-3 rounded-md flex items-center text-sm font-medium",
-          overallSystemStatus.color === "text-green-500" && "bg-green-500/10 border border-green-500/30",
-          overallSystemStatus.color === "text-yellow-500" && "bg-yellow-500/10 border border-yellow-500/30",
-          overallSystemStatus.color === "text-red-500" && "bg-red-500/10 border border-red-500/30"
+          overallSystemStatus.color === "text-success" && "bg-green-500/10 border border-green-500/30",
+          overallSystemStatus.color === "text-warning" && "bg-yellow-500/10 border border-yellow-500/30",
+          overallSystemStatus.color === "text-danger" && "bg-red-500/10 border border-red-500/30"
         )}>
           <OverallStatusIcon className={cn("h-5 w-5 mr-2", overallSystemStatus.color)} />
           Overall: {overallSystemStatus.text}

--- a/src/components/dpp-dashboard/MetricCard.tsx
+++ b/src/components/dpp-dashboard/MetricCard.tsx
@@ -27,10 +27,10 @@ export const MetricCard: React.FC<MetricCardProps> = ({
 
   if (trendDirection === "up") {
     TrendIcon = ArrowUpCircle;
-    trendColor = "text-green-500";
+    trendColor = "text-success";
   } else if (trendDirection === "down") {
     TrendIcon = ArrowDownCircle;
-    trendColor = "text-red-500";
+    trendColor = "text-danger";
   }
 
   return (

--- a/src/components/products/ProductLifecycleFlowchart.tsx
+++ b/src/components/products/ProductLifecycleFlowchart.tsx
@@ -82,9 +82,9 @@ const getStatusClasses = (status: LifecyclePhase['status'], isCurrent: boolean) 
 };
 
 const MetricStatusIcon = ({ status }: { status: Metric['status'] }) => {
-  if (status === 'compliant') return <CheckCircle className="h-4 w-4 text-green-500" />;
-  if (status === 'non_compliant') return <AlertCircle className="h-4 w-4 text-red-500" />;
-  if (status === 'pending_review') return <InfoIcon className="h-4 w-4 text-yellow-500" />;
+  if (status === 'compliant') return <CheckCircle className="h-4 w-4 text-success" />;
+  if (status === 'non_compliant') return <AlertCircle className="h-4 w-4 text-danger" />;
+  if (status === 'pending_review') return <InfoIcon className="h-4 w-4 text-warning" />;
   return <Minus className="h-4 w-4 text-muted-foreground" />;
 };
 
@@ -260,7 +260,7 @@ const ProductLifecycleFlowchart: React.FC<ProductLifecycleFlowchartProps> = ({ p
                                      <span className="font-medium">{metric.name}:</span>
                                      <span>{metric.value}{metric.unit && ` ${metric.unit}`}
                                       {typeof metric.value === 'number' && metric.targetValue !== undefined && (
-                                        <span className={cn("ml-1 text-xs", metric.value <= metric.targetValue ? 'text-green-500' : 'text-red-500')}>
+                                        <span className={cn("ml-1 text-xs", metric.value <= metric.targetValue ? 'text-success' : 'text-danger')}>
                                           ({metric.value <= metric.targetValue ? <TrendingUp className="inline h-3 w-3"/> : <TrendingDown className="inline h-3 w-3"/>} vs {metric.targetValue}{metric.unit && ` ${metric.unit}`})
                                         </span>
                                       )}

--- a/src/components/products/detail/CertificationsTab.tsx
+++ b/src/components/products/detail/CertificationsTab.tsx
@@ -48,7 +48,7 @@ export default function CertificationsTab({ product }: CertificationsTabProps) {
             <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-2">
               <h4 className="font-medium text-md text-foreground flex items-center">
                 {cert.isVerified ? (
-                  <ShieldCheck className="mr-2 h-5 w-5 text-green-500 flex-shrink-0" />
+                  <ShieldCheck className="mr-2 h-5 w-5 text-success flex-shrink-0" />
                 ) : (
                   <FileText className="mr-2 h-5 w-5 text-muted-foreground flex-shrink-0" />
                 )}

--- a/src/components/products/detail/OverviewTab.tsx
+++ b/src/components/products/detail/OverviewTab.tsx
@@ -126,7 +126,7 @@ export default function OverviewTab({ product }: OverviewTabProps) {
                 <ul className="space-y-1.5 text-sm">
                   {product.keySustainabilityPoints.map((point, index) => (
                     <li key={index} className="flex items-center">
-                      <CheckCircle className="h-4 w-4 mr-2 text-green-500 flex-shrink-0" />
+                      <CheckCircle className="h-4 w-4 mr-2 text-success flex-shrink-0" />
                       {point}
                     </li>
                   ))}

--- a/src/components/products/detail/SustainabilityTab.tsx
+++ b/src/components/products/detail/SustainabilityTab.tsx
@@ -48,7 +48,7 @@ export default function SustainabilityTab({ product }: SustainabilityTabProps) {
             <ul className="space-y-2 text-sm">
               {product.keySustainabilityPoints.map((point, index) => (
                 <li key={index} className="flex items-start">
-                  <CheckCircle className="h-4 w-4 mr-2 mt-0.5 text-green-500 flex-shrink-0" />
+                  <CheckCircle className="h-4 w-4 mr-2 mt-0.5 text-success flex-shrink-0" />
                   <span>{point}</span>
                 </li>
               ))}
@@ -88,7 +88,7 @@ export default function SustainabilityTab({ product }: SustainabilityTabProps) {
       <Card className="shadow-sm">
         <CardHeader>
           <CardTitle className="text-lg font-semibold flex items-center">
-            <Zap className="mr-2 h-5 w-5 text-yellow-500" /> Energy Efficiency
+            <Zap className="mr-2 h-5 w-5 text-warning" /> Energy Efficiency
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-2">

--- a/src/utils/dppDisplayUtils.tsx
+++ b/src/utils/dppDisplayUtils.tsx
@@ -46,11 +46,11 @@ export const getOverallComplianceDetails = (dpp: DigitalProductPassport): Compli
     return { text: "Non-Compliant", variant: "destructive", icon: iconElement, tooltipText: "One or more regulations are non-compliant." };
   }
   if (pendingCount > 0) {
-    const iconElement = <InfoIcon className="h-5 w-5 text-yellow-500" />;
+    const iconElement = <InfoIcon className="h-5 w-5 text-warning" />;
     return { text: "Pending", variant: "outline", icon: iconElement, tooltipText: "One or more regulations are pending." };
   }
   if (compliantCount === regulationsChecked.length && regulationsChecked.length > 0) {
-    const iconElement = <ShieldCheck className="h-5 w-5 text-green-500" />;
+    const iconElement = <ShieldCheck className="h-5 w-5 text-success" />;
     return { text: "Fully Compliant", variant: "default", icon: iconElement, tooltipText: "All tracked regulations compliant." };
   }
   const iconElementDefault = <ShieldQuestion className="h-5 w-5 text-muted-foreground" />;
@@ -64,13 +64,13 @@ export const getEbsiStatusDetails = (status?: EbsiVerificationDetails['status'])
   }
   switch (status) {
     case 'verified':
-      const verifiedIcon = <ShieldCheck className="h-4 w-4 text-green-500" />;
+      const verifiedIcon = <ShieldCheck className="h-4 w-4 text-success" />;
       return { text: "Verified", variant: "default", icon: verifiedIcon, tooltipText: "EBSI verification successful." };
     case 'pending_verification':
-      const pendingIcon = <InfoIcon className="h-4 w-4 text-yellow-500" />;
+      const pendingIcon = <InfoIcon className="h-4 w-4 text-warning" />;
       return { text: "Pending", variant: "outline", icon: pendingIcon, tooltipText: "EBSI verification pending." };
     case 'not_verified':
-      const notVerifiedIcon = <AlertCircle className="h-4 w-4 text-red-500" />;
+      const notVerifiedIcon = <AlertCircle className="h-4 w-4 text-danger" />;
       return { text: "Not Verified", variant: "destructive", icon: notVerifiedIcon, tooltipText: "EBSI verification failed." };
     case 'error':
       const errorIcon = <AlertTriangle className="h-4 w-4 text-red-700" />;
@@ -169,12 +169,12 @@ export const getStatusIcon = (status?: string): JSX.Element => {
     case 'verified':
     case 'synced successfully':
     case 'conformant': // Added from overall compliance logic
-      return <ShieldCheck className="h-5 w-5 text-green-500" />;
+      return <ShieldCheck className="h-5 w-5 text-success" />;
     case 'non-compliant':
     case 'non_conformant': // Added from overall compliance logic
     case 'error':
     case 'error during sync':
-      return <AlertTriangle className="h-5 w-5 text-red-500" />;
+      return <AlertTriangle className="h-5 w-5 text-danger" />;
     case 'pending':
     case 'pending review':
     case 'pending_review': // Ensure this is caught
@@ -184,7 +184,7 @@ export const getStatusIcon = (status?: string): JSX.Element => {
     case 'data incomplete':
     case 'data mismatch':
     case 'product not found in eprel':
-      return <InfoIcon className="h-5 w-5 text-yellow-500" />;
+      return <InfoIcon className="h-5 w-5 text-warning" />;
     case 'not applicable':
     case 'n/a':
     case 'not found':


### PR DESCRIPTION
## Summary
- add custom `.text-success`, `.text-warning`, `.text-danger` utilities
- use new semantic classes across the app
- update `statusColor` props to reference new classes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ba9465c8832a9df40a97d26cd33e