### PR TITLE
Add skip link and accessibility labels

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -15,7 +15,7 @@ export default function AppLayout({ children }: { children: ReactNode }) {
     // Render a simplified layout for the developer portal
     // RoleProvider is inherited from the root layout
     return (
-      <main className="flex-1 p-4 md:p-6 lg:p-8 bg-background text-foreground min-h-screen">
+      <main id="main-content" className="flex-1 p-4 md:p-6 lg:p-8 bg-background text-foreground min-h-screen">
         {children}
       </main>
     );
@@ -30,7 +30,7 @@ export default function AppLayout({ children }: { children: ReactNode }) {
       </Sidebar>
       <SidebarInset>
         <AppHeader />
-        <main className="flex-1 p-4 md:p-6 lg:p-8">
+        <main id="main-content" className="flex-1 p-4 md:p-6 lg:p-8">
           {children}
         </main>
       </SidebarInset>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type {Metadata} from 'next';
 import './globals.css';
 import { Toaster } from "@/components/ui/toaster"
 import { RoleProvider } from '@/contexts/RoleContext'; // Import RoleProvider
+import { SkipToContent } from '@/components/layout/SkipToContent'
 
 export const metadata: Metadata = {
   title: 'Norruva Digital Product Passport',
@@ -22,6 +23,7 @@ export default function RootLayout({
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
       </head>
       <body className="font-body antialiased">
+        <SkipToContent />
         <RoleProvider> {/* RoleProvider now wraps all children at the root level */}
           {children}
         </RoleProvider>

--- a/src/app/passport/[passportId]/page.tsx
+++ b/src/app/passport/[passportId]/page.tsx
@@ -107,7 +107,7 @@ export default function PublicPassportPage({ params }: Props) {
         </div>
       </header>
 
-      <main className="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
+      <main id="main-content" className="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
         <div className="bg-card p-6 sm:p-8 rounded-xl shadow-xl">
           <div className="text-center mb-8">
             <h1 className="font-headline text-3xl md:text-4xl font-semibold text-primary mb-2">

--- a/src/components/developer/ApiKeysManager.tsx
+++ b/src/components/developer/ApiKeysManager.tsx
@@ -84,24 +84,28 @@ export default function ApiKeysManager({
                   </Badge>
                 </TableCell>
                 <TableCell className="text-right space-x-2">
-                  <Button 
-                    variant="ghost" 
-                    size="icon" 
-                    onClick={() => onCopyKey(apiKey.key)} 
-                    title="Copy Key" 
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Copy API key"
+                    onClick={() => onCopyKey(apiKey.key)}
+                    title="Copy Key"
                     disabled={apiKey.status === 'Pending Approval' || apiKey.key.startsWith("N/A") || apiKey.status === 'Revoked'}
                   >
                     <Copy className="h-4 w-4" />
+                    <span className="sr-only">Copy API key</span>
                   </Button>
-                  <Button 
-                    variant="ghost" 
-                    size="icon" 
-                    title="Delete Key" 
-                    onClick={() => onDeleteApiKey(apiKey.id)} 
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Delete API key"
+                    title="Delete Key"
+                    onClick={() => onDeleteApiKey(apiKey.id)}
                     className="text-destructive hover:text-destructive"
                     disabled={apiKey.status === 'Revoked'} // Optionally disable delete for revoked keys
                   >
                     <Trash2 className="h-4 w-4" />
+                    <span className="sr-only">Delete API key</span>
                   </Button>
                 </TableCell>
               </TableRow>

--- a/src/components/developer/WebhooksManager.tsx
+++ b/src/components/developer/WebhooksManager.tsx
@@ -67,11 +67,13 @@ export default function WebhooksManager({
                   </Badge>
                 </TableCell>
                 <TableCell className="text-right space-x-1">
-                  <Button variant="ghost" size="icon" title="Edit Webhook" onClick={() => onEditWebhook(wh.id)}>
+                  <Button variant="ghost" size="icon" aria-label="Edit webhook" title="Edit Webhook" onClick={() => onEditWebhook(wh.id)}>
                     <Edit2 className="h-4 w-4" />
+                    <span className="sr-only">Edit webhook</span>
                   </Button>
-                  <Button variant="ghost" size="icon" title="Delete Webhook" onClick={() => onDeleteWebhook(wh.id)} className="text-destructive hover:text-destructive">
+                  <Button variant="ghost" size="icon" aria-label="Delete webhook" title="Delete Webhook" onClick={() => onDeleteWebhook(wh.id)} className="text-destructive hover:text-destructive">
                     <Trash2 className="h-4 w-4" />
+                    <span className="sr-only">Delete webhook</span>
                   </Button>
                 </TableCell>
               </TableRow>

--- a/src/components/layout/SkipToContent.tsx
+++ b/src/components/layout/SkipToContent.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+export function SkipToContent({ className }: { className?: string }) {
+  return (
+    <a
+      href="#main-content"
+      className={cn(
+        "sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 z-50 bg-primary text-primary-foreground rounded-md p-2",
+        className
+      )}
+    >
+      Skip to content
+    </a>
+  );
+}

--- a/src/components/products/detail/SupplyChainTab.tsx
+++ b/src/components/products/detail/SupplyChainTab.tsx
@@ -235,8 +235,9 @@ export default function SupplyChainTab({ product, onSupplyChainLinksChange }: Su
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <div className="inline-block" tabIndex={!canManageLinks ? 0 : undefined}>
-                                        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => handleOpenEditDialog(link)} title="Edit Link" disabled={!canManageLinks}>
+                                        <Button variant="ghost" size="icon" aria-label="Edit link" className="h-7 w-7" onClick={() => handleOpenEditDialog(link)} title="Edit Link" disabled={!canManageLinks}>
                                            <EditIcon className="h-4 w-4" />
+                                           <span className="sr-only">Edit link</span>
                                         </Button>
                                     </div>
                                 </TooltipTrigger>
@@ -251,8 +252,9 @@ export default function SupplyChainTab({ product, onSupplyChainLinksChange }: Su
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                      <div className="inline-block" tabIndex={!canManageLinks ? 0 : undefined}>
-                                        <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:text-destructive" onClick={() => handleUnlinkSupplier(link.supplierId, link.suppliedItem)} title="Unlink Supplier" disabled={!canManageLinks}>
+                                        <Button variant="ghost" size="icon" aria-label="Unlink supplier" className="h-7 w-7 text-destructive hover:text-destructive" onClick={() => handleUnlinkSupplier(link.supplierId, link.suppliedItem)} title="Unlink Supplier" disabled={!canManageLinks}>
                                           <Trash2 className="h-4 w-4" />
+                                          <span className="sr-only">Unlink supplier</span>
                                         </Button>
                                     </div>
                                 </TooltipTrigger>

--- a/src/components/products/form/CustomAttributesFormSection.tsx
+++ b/src/components/products/form/CustomAttributesFormSection.tsx
@@ -107,15 +107,16 @@ export default function CustomAttributesFormSection({
                   <span className="font-medium text-sm text-primary">{attr.key}:</span>
                   <span className="text-sm text-foreground/90 ml-1.5">{attr.value}</span>
                 </div>
-                <Button 
-                  type="button" 
-                  variant="ghost" 
-                  size="icon" 
-                  onClick={() => internalHandleAddSuggestedAttribute(attr)} 
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => internalHandleAddSuggestedAttribute(attr)}
                   className="h-7 w-7 text-green-600 hover:text-green-700 hover:bg-green-500/10"
                   title={`Add attribute "${attr.key}"`}
                 >
                   <PlusCircle className="h-4.5 w-4.5" />
+                  <span className="sr-only">Add attribute {attr.key}</span>
                 </Button>
               </li>
             ))}
@@ -135,15 +136,16 @@ export default function CustomAttributesFormSection({
                   <span className="font-semibold text-primary">{attr.key}:</span>
                   <span className="text-foreground/90 ml-1.5">{attr.value}</span>
                 </div>
-                <Button 
-                  type="button" 
-                  variant="ghost" 
-                  size="icon" 
-                  onClick={() => handleRemoveCustomAttribute(attr.key)} 
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleRemoveCustomAttribute(attr.key)}
                   className="h-7 w-7 text-destructive hover:text-destructive hover:bg-destructive/10"
                   title={`Remove ${attr.key}`}
                 >
                   <XCircle className="h-4.5 w-4.5" />
+                  <span className="sr-only">Remove attribute {attr.key}</span>
                 </Button>
               </li>
             ))}

--- a/src/components/suppliers/SupplierList.tsx
+++ b/src/components/suppliers/SupplierList.tsx
@@ -63,8 +63,9 @@ export default function SupplierList({ suppliers, onEditSupplier, onDeleteSuppli
               <TableCell className="text-right">
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" size="icon">
+                    <Button variant="ghost" size="icon" aria-label="Supplier actions">
                       <MoreHorizontal className="h-4 w-4" />
+                      <span className="sr-only">Actions for {supplier.name}</span>
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">


### PR DESCRIPTION
## Summary
- add a `SkipToContent` component and include in root layout
- give each page's `<main>` element an `id` for skip link target
- add accessible labels to icon-only buttons across the app

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: tsc missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6848bb264fc4832a91c07594439dcc71