### PR TITLE
Fix dev port and add workstation troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Welcome to the Norruva Digital Product Passport (DPP) concept application! This 
   - [Installation](#installation)
   - [Running the Development Server](#running-the-development-server)
   - [Running Tests](#running-tests)
+  - [Troubleshooting](#troubleshooting)
 - [Key Directory Structure](#key-directory-structure)
 - [Firebase Studio Context](#firebase-studio-context)
 
@@ -123,7 +124,19 @@ Run the unit tests with:
 npm test
 ```
 
+
 Use `npm run test:watch` during development to re-run tests on file changes.
+
+### Troubleshooting
+
+**401: The Workstation does not exist or your currently signed in account does not have access to it**
+
+This error may appear when using the "View Public Passport" link in a Cloud Workstations environment. Verify that:
+
+1. The workstation `firebase-studio-1749131649534` (cluster `workstation-cluster-9`) exists and is running in project `510861787045`.
+2. Your Google account has the `workstations.workstations.use` IAM permission (e.g., via the *Workstations User* role) on that workstation.
+
+Without this permission Google Cloud cannot generate the access token required to open the application.
 
 ## Key Directory Structure
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack -p 9003",
+    "dev": "next dev --turbopack -p 9002",
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
     "build": "next build",

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -13,6 +13,7 @@ Welcome to the Norruva Digital Product Passport (DPP) concept application! This 
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
   - [Running the Development Server](#running-the-development-server)
+  - [Troubleshooting](#troubleshooting)
 - [Key Directory Structure](#key-directory-structure)
 - [Firebase Studio Context](#firebase-studio-context)
 
@@ -109,6 +110,12 @@ Links from other parts of the application, such as the "Products" listing page (
     This will start the Next.js application, usually on `http://localhost:9002` (as configured in `package.json`).
 
 Open `http://localhost:9002` in your browser to view the application.
+
+### Troubleshooting
+
+**401: The Workstation does not exist or your currently signed in account does not have access to it**
+
+Ensure your Google Cloud Workstation is running and that your account has the `workstations.workstations.use` permission (usually via the *Workstations User* role). Without this permission, the "View Public Passport" link cannot generate an access token.
 
 ## Key Directory Structure
 


### PR DESCRIPTION
## Summary
- fix `npm run dev` port to match docs
- document Cloud Workstation permission requirements in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848aedc43a8832a87d2c7b188a95bb4