### PR TITLE
Add sorting utility for DPP table

### DIFF
--- a/src/hooks/useDPPLiveData.ts
+++ b/src/hooks/useDPPLiveData.ts
@@ -7,6 +7,7 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import type { DigitalProductPassport, DashboardFiltersState, SortConfig, SortableKeys } from '@/types/dpp';
 import { MOCK_DPPS } from '@/types/dpp'; // Assuming MOCK_DPPS are still needed for base data
+import { getSortValue } from '@/utils/sortUtils';
 import { useToast } from '@/hooks/use-toast';
 
 const USER_PRODUCTS_LOCAL_STORAGE_KEY = 'norruvaUserProducts';
@@ -59,31 +60,16 @@ export function useDPPLiveData() {
 
     if (sortConfig.key && sortConfig.direction) {
       filtered.sort((a, b) => {
-        let valA: any, valB: any;
-        if (sortConfig.key === 'metadata.status') valA = a.metadata.status;
-        else if (sortConfig.key === 'metadata.last_updated') valA = new Date(a.metadata.last_updated).getTime();
-        else if (sortConfig.key === 'ebsiVerification.status') valA = a.ebsiVerification?.status;
-        else {
-             valA = a[sortConfig.key as keyof DigitalProductPassport];
-             valB = b[sortConfig.key as keyof DigitalProductPassport];
-        }
-        
-        if (sortConfig.key === 'metadata.status') valB = b.metadata.status;
-        else if (sortConfig.key === 'metadata.last_updated') valB = new Date(b.metadata.last_updated).getTime();
-        else if (sortConfig.key === 'ebsiVerification.status') valB = b.ebsiVerification?.status;
-        // Ensure valB is assigned if not covered by the specific 'else if' blocks for valA
-        // Only assign if valB is actually undefined to allow falsy but valid values like 0
-        else if (valB === undefined) {
-             valB = b[sortConfig.key as keyof DigitalProductPassport];
-        }
+        let valA: any = getSortValue(a, sortConfig.key!);
+        let valB: any = getSortValue(b, sortConfig.key!);
 
         if (typeof valA === 'string' && typeof valB === 'string') {
           valA = valA.toLowerCase();
           valB = valB.toLowerCase();
         }
-        
-        const valAExists = valA !== undefined && valA !== null && valA !== "";
-        const valBExists = valB !== undefined && valB !== null && valB !== "";
+
+        const valAExists = valA !== undefined && valA !== null && valA !== '';
+        const valBExists = valB !== undefined && valB !== null && valB !== '';
 
         if (!valAExists && valBExists) return sortConfig.direction === 'ascending' ? 1 : -1;
         if (valAExists && !valBExists) return sortConfig.direction === 'ascending' ? -1 : 1;

--- a/src/utils/__tests__/sortUtils.test.ts
+++ b/src/utils/__tests__/sortUtils.test.ts
@@ -1,0 +1,26 @@
+import { getSortValue } from '../sortUtils';
+import type { DigitalProductPassport } from '@/types/dpp';
+
+const mockDpp: DigitalProductPassport = {
+  id: '1',
+  productName: 'Test',
+  category: 'cat',
+  metadata: { last_updated: '2024-01-01T00:00:00Z', status: 'draft' },
+  compliance: {},
+};
+
+describe('getSortValue', () => {
+  it('handles metadata.status', () => {
+    expect(getSortValue(mockDpp, 'metadata.status')).toBe('draft');
+  });
+  it('handles metadata.last_updated', () => {
+    expect(getSortValue(mockDpp, 'metadata.last_updated')).toBe(new Date('2024-01-01T00:00:00Z').getTime());
+  });
+  it('handles ebsiVerification.status', () => {
+    const dppWithEbsi: DigitalProductPassport = { ...mockDpp, ebsiVerification: { status: 'verified', lastChecked: '2024-01-02T00:00:00Z' } };
+    expect(getSortValue(dppWithEbsi, 'ebsiVerification.status')).toBe('verified');
+  });
+  it('handles default keys', () => {
+    expect(getSortValue(mockDpp, 'productName')).toBe('Test');
+  });
+});

--- a/src/utils/sortUtils.ts
+++ b/src/utils/sortUtils.ts
@@ -1,0 +1,21 @@
+// --- File: src/utils/sortUtils.ts ---
+// Description: Utility functions for sorting Digital Product Passports.
+
+import type { DigitalProductPassport, SortableKeys } from '@/types/dpp';
+
+/**
+ * Returns the value to use when sorting a DPP by the given key.
+ * Handles nested keys and special cases.
+ */
+export function getSortValue(dpp: DigitalProductPassport, key: SortableKeys): any {
+  switch (key) {
+    case 'metadata.status':
+      return dpp.metadata.status;
+    case 'metadata.last_updated':
+      return new Date(dpp.metadata.last_updated).getTime();
+    case 'ebsiVerification.status':
+      return dpp.ebsiVerification?.status;
+    default:
+      return (dpp as any)[key];
+  }
+}


### PR DESCRIPTION
## Summary
- add `getSortValue` util for easier DPP sorting
- refactor `useDPPLiveData` to use the new util
- cover `getSortValue` with unit tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848cfa37b88832aab6ce810edd0dc5a