### PR TITLE
Unify repo on Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,5 +4,5 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1'
   },
-  testMatch: ['**/__tests__/**/*.ts']
+  testMatch: ['**/__tests__/**/*.(ts|tsx)']
 };

--- a/workspace/package.json
+++ b/workspace/package.json
@@ -10,7 +10,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "jest"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.8.0",
@@ -67,7 +67,6 @@
     "genkit-cli": "^1.8.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5",
-    "vitest": "^1.5.1"
+    "typescript": "^5"
   }
 }

--- a/workspace/src/utils/__tests__/aiFormHelpers.test.tsx
+++ b/workspace/src/utils/__tests__/aiFormHelpers.test.tsx
@@ -1,6 +1,6 @@
 
 // --- File: src/utils/__tests__/aiFormHelpers.test.tsx ---
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+
 import type { UseFormReturn } from 'react-hook-form';
 import type { ProductFormData } from '@/components/products/ProductForm';
 import type { ToastInput } from '@/hooks/use-toast';
@@ -13,32 +13,32 @@ import {
 } from '../aiFormHelpers';
 
 // Mock AI Flow functions
-vi.mock('@/ai/flows/generate-product-name-flow', () => ({
-  generateProductName: vi.fn(),
+jest.mock('@/ai/flows/generate-product-name-flow', () => ({
+  generateProductName: jest.fn(),
 }));
-vi.mock('@/ai/flows/generate-product-image-flow', () => ({
-  generateProductImage: vi.fn(),
+jest.mock('@/ai/flows/generate-product-image-flow', () => ({
+  generateProductImage: jest.fn(),
 }));
 // Add mocks for other AI flows as needed for other helper functions
 
 // Helper to create a mock form object
 const createMockForm = (): Partial<UseFormReturn<ProductFormData>> => ({
-  getValues: vi.fn(),
-  setValue: vi.fn(),
+  getValues: jest.fn(),
+  setValue: jest.fn(),
 });
 
 // Mock toast function
-const mockToast = vi.fn();
-const mockSetLoadingState = vi.fn();
+const mockToast = jest.fn();
+const mockSetLoadingState = jest.fn();
 
 describe('aiFormHelpers', () => {
   let mockForm: Partial<UseFormReturn<ProductFormData>>;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    jest.clearAllMocks();
     mockForm = createMockForm();
     // Default mock implementations
-    (mockForm.getValues as vi.Mock).mockReturnValue({
+    (mockForm.getValues as jest.Mock).mockReturnValue({
       productDescription: 'A great test product',
       productCategory: 'Testing',
       productName: 'Test Product Name', // For image generation
@@ -51,7 +51,7 @@ describe('aiFormHelpers', () => {
 
     it('should call generateProductName and update form on success', async () => {
       const suggestedName = 'AI Suggested Name';
-      (generateProductName as vi.Mock).mockResolvedValue({ productName: suggestedName });
+      (generateProductName as jest.Mock).mockResolvedValue({ productName: suggestedName });
 
       const result = await handleSuggestNameAI(
         mockForm as UseFormReturn<ProductFormData>,
@@ -74,7 +74,7 @@ describe('aiFormHelpers', () => {
     });
 
     it('should show error toast if input is insufficient', async () => {
-      (mockForm.getValues as vi.Mock).mockReturnValue({}); // No description or category
+      (mockForm.getValues as jest.Mock).mockReturnValue({}); // No description or category
 
       const result = await handleSuggestNameAI(
         mockForm as UseFormReturn<ProductFormData>,
@@ -94,7 +94,7 @@ describe('aiFormHelpers', () => {
 
     it('should show error toast if AI flow fails', async () => {
       const errorMessage = 'AI service unavailable';
-      (generateProductName as vi.Mock).mockRejectedValue(new Error(errorMessage));
+      (generateProductName as jest.Mock).mockRejectedValue(new Error(errorMessage));
 
       const result = await handleSuggestNameAI(
         mockForm as UseFormReturn<ProductFormData>,
@@ -117,7 +117,7 @@ describe('aiFormHelpers', () => {
 
     it('should call generateProductImage and return image URL on success', async () => {
       const imageUrl = 'data:image/png;base64,mockimage';
-      (generateProductImage as vi.Mock).mockResolvedValue({ imageUrl });
+      (generateProductImage as jest.Mock).mockResolvedValue({ imageUrl });
 
       const result = await handleGenerateImageAI(
         mockForm as UseFormReturn<ProductFormData>,
@@ -141,7 +141,7 @@ describe('aiFormHelpers', () => {
     });
 
     it('should show error toast if product name is missing', async () => {
-      (mockForm.getValues as vi.Mock).mockReturnValue({ productCategory: 'Testing' }); // No productName
+      (mockForm.getValues as jest.Mock).mockReturnValue({ productCategory: 'Testing' }); // No productName
 
       const result = await handleGenerateImageAI(
         mockForm as UseFormReturn<ProductFormData>,
@@ -161,7 +161,7 @@ describe('aiFormHelpers', () => {
 
     it('should show error toast if AI image generation fails', async () => {
       const errorMessage = 'Image generation service error';
-      (generateProductImage as vi.Mock).mockRejectedValue(new Error(errorMessage));
+      (generateProductImage as jest.Mock).mockRejectedValue(new Error(errorMessage));
 
       const result = await handleGenerateImageAI(
         mockForm as UseFormReturn<ProductFormData>,

--- a/workspace/src/utils/__tests__/apiPlaygroundUtils.test.ts
+++ b/workspace/src/utils/__tests__/apiPlaygroundUtils.test.ts
@@ -1,5 +1,5 @@
 
-import { describe, it, expect } from 'vitest';
+
 import { generateMockCodeSnippet } from '../apiPlaygroundUtils';
 
 describe('generateMockCodeSnippet', () => {

--- a/workspace/src/utils/__tests__/dppDisplayUtils.test.tsx
+++ b/workspace/src/utils/__tests__/dppDisplayUtils.test.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+
 import { getStatusIcon, getStatusBadgeVariant, getStatusBadgeClasses, getOverallComplianceDetails, getEbsiStatusDetails } from '../dppDisplayUtils';
 import type { DigitalProductPassport, EbsiVerificationDetails } from '@/types/dpp'; // Ensure types are imported
 import { ShieldCheck, ShieldAlert, ShieldQuestion, Info as InfoIcon, AlertTriangle } from 'lucide-react';

--- a/workspace/src/utils/__tests__/fileUtils.test.ts
+++ b/workspace/src/utils/__tests__/fileUtils.test.ts
@@ -1,15 +1,15 @@
 
-import { describe, it, expect, vi } from 'vitest';
+
 import { fileToDataUri } from '../fileUtils';
 
 // Mock FileReader
 const mockFileReader = {
-  readAsDataURL: vi.fn(),
-  onload: vi.fn(),
-  onerror: vi.fn(),
+  readAsDataURL: jest.fn(),
+  onload: jest.fn(),
+  onerror: jest.fn(),
   result: '',
 };
-vi.stubGlobal('FileReader', vi.fn(() => mockFileReader));
+(global as any).FileReader = jest.fn(() => mockFileReader);
 
 // Mock File
 const createMockFile = (name = 'test.png', type = 'image/png', content = ['content']) => {
@@ -23,7 +23,7 @@ describe('fileToDataUri', () => {
     const mockDataUri = 'data:image/png;base64,Y29udGVudA=='; // "content" base64 encoded
 
     // Simulate successful load
-    mockFileReader.readAsDataURL = vi.fn((file) => {
+    mockFileReader.readAsDataURL = jest.fn((file) => {
       expect(file).toBe(mockFile);
       mockFileReader.result = mockDataUri;
       // Call onload directly as if the event triggered
@@ -45,7 +45,7 @@ describe('fileToDataUri', () => {
     const mockError = new Error('File read failed');
 
     // Simulate error
-    mockFileReader.readAsDataURL = vi.fn((file) => {
+    mockFileReader.readAsDataURL = jest.fn((file) => {
       expect(file).toBe(mockFile);
       // Call onerror directly as if the event triggered
       if (typeof mockFileReader.onerror === 'function') {

--- a/workspace/src/utils/__tests__/imageUtils.test.ts
+++ b/workspace/src/utils/__tests__/imageUtils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+
 import { getAiHintForImage } from '../imageUtils';
 
 describe('getAiHintForImage', () => {

--- a/workspace/src/utils/__tests__/productDetailUtils.test.ts
+++ b/workspace/src/utils/__tests__/productDetailUtils.test.ts
@@ -1,5 +1,5 @@
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
 import { fetchProductDetails } from '../productDetailUtils';
 import { MOCK_DPPS, USER_PRODUCTS_LOCAL_STORAGE_KEY } from '@/types/dpp';
 import type { StoredUserProduct, DigitalProductPassport } from '@/types/dpp';
@@ -21,7 +21,7 @@ const localStorageMock = (() => {
   };
 })();
 
-vi.stubGlobal('localStorage', localStorageMock);
+(global as any).localStorage = localStorageMock;
 
 
 describe('fetchProductDetails', () => {


### PR DESCRIPTION
## Summary
- move test framework to Jest across workspace
- drop Vitest dependency and use Jest in scripts
- update test files to rely on Jest globals
- allow tsx tests in `jest.config.js`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run typecheck` *(fails: cannot find modules)*


------
https://chatgpt.com/codex/tasks/task_e_6848e9421d1c832a80ae70162c183e09