### PR TITLE
Add QR generation endpoint and docs

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -720,6 +720,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/qr/generate/{productId}:
+    get:
+      operationId: generateQrCode
+      summary: Generate QR Code for a Product
+      description: Returns a QR code image that links to the product's public passport.
+      parameters:
+        - name: productId
+          in: path
+          required: true
+          description: The unique identifier of the product.
+          schema:
+            type: string
+            example: DPP001
+      responses:
+        '200':
+          description: PNG image of the QR code.
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+              example: iVBORw0KGgoAAA
+        '401':
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Product not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/v1/qr/validate:
     post:
       operationId: validateQrCode

--- a/src/app/(app)/developer/docs/page.tsx
+++ b/src/app/(app)/developer/docs/page.tsx
@@ -21,8 +21,9 @@ import {
     Layers as LayersIcon, 
     Users, 
     ShieldCheck, 
-    TestTube2, 
-    Server as ServerIconShadcn, 
+    TestTube2,
+    QrCode,
+    Server as ServerIconShadcn,
     VenetianMask,
     History 
 } from "lucide-react";
@@ -76,6 +77,7 @@ export default function DeveloperDocumentationHubPage() {
               <li><Link href="/developer/docs/ebsi-integration" className="text-primary hover:underline flex items-center"><Share2 className="mr-2 h-4 w-4" />EBSI Integration Overview</Link></li>
               <li><Link href="/developer/docs/regulatory-alignment" className="text-primary hover:underline flex items-center"><Scale className="mr-2 h-4 w-4" />Regulatory Alignment (ESPR, EPREL)</Link></li>
               <li><Link href="/developer/docs/data-management-best-practices" className="text-primary hover:underline flex items-center"><LayersIcon className="mr-2 h-4 w-4" />Data Management Best Practices</Link></li>
+              <li><Link href="/developer/docs/qr-code-embedding" className="text-primary hover:underline flex items-center"><QrCode className="mr-2 h-4 w-4" />QR Code Generation &amp; Embedding</Link></li>
               <li><Link href="/developer/guides/auditor-integration" className="text-primary hover:underline flex items-center"><ShieldCheck className="mr-2 h-4 w-4" />Auditor Integration</Link></li>
             </ul>
           </div>

--- a/src/app/(app)/developer/docs/qr-code-embedding/page.tsx
+++ b/src/app/(app)/developer/docs/qr-code-embedding/page.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import DocsPageLayout from '@/components/developer/DocsPageLayout';
+import { QrCode } from "lucide-react";
+
+export default function QrCodeEmbeddingPage() {
+  return (
+    <DocsPageLayout
+      pageTitle="QR Code Generation & Embedding"
+      pageIcon="QrCode"
+      alertTitle="Conceptual Documentation"
+      alertDescription="How to obtain a QR image from the API and embed it in your applications."
+    >
+      <Card className="shadow-lg">
+        <CardHeader>
+          <CardTitle>Generate a QR Code</CardTitle>
+          <CardDescription>
+            Request the image using <code className="bg-muted px-1 py-0.5 rounded-sm">/api/v1/qr/generate/&lt;productId&gt;</code>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p className="text-sm">Example request:</p>
+          <pre className="bg-muted p-3 rounded-md text-xs overflow-x-auto"><code>GET /api/v1/qr/generate/DPP001</code></pre>
+          <p className="text-sm">Successful responses return a PNG image (<code>image/png</code>).</p>
+        </CardContent>
+      </Card>
+
+      <Card className="shadow-lg mt-6">
+        <CardHeader>
+          <CardTitle>Embedding</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p className="text-sm">Include the endpoint as the <code>src</code> for an image tag:</p>
+          <pre className="bg-muted p-3 rounded-md text-xs overflow-x-auto"><code>{`<img src="https://api.example.com/api/v1/qr/generate/DPP001" alt="Product QR" />`}</code></pre>
+          <p className="text-sm">Scanning the QR directs users to the product's public passport.</p>
+        </CardContent>
+      </Card>
+    </DocsPageLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/api/v1/qr/generate/{productId}` path to openapi spec
- document how to generate and embed QR codes
- link new docs from the documentation hub

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6848fbe0e228832aaf8de6028c6579f6