### PR TITLE
Add API key auth middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ GOOGLE_API_KEY=
 # Path to Google Cloud service account credentials (optional)
 GOOGLE_APPLICATION_CREDENTIALS=
 
+# Comma-separated list of valid API keys used by the API middleware
+VALID_API_KEYS=SANDBOX_KEY_123,PROD_KEY_456
+

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Welcome to the Norruva Digital Product Passport (DPP) concept application! This 
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
   - [Running the Development Server](#running-the-development-server)
-  - [Running Tests](#running-tests)
+- [Running Tests](#running-tests)
+  - [Authentication](#authentication)
   - [Troubleshooting](#troubleshooting)
 - [Key Directory Structure](#key-directory-structure)
 - [Firebase Studio Context](#firebase-studio-context)
@@ -188,6 +189,20 @@ npm test
 
 
 Use `npm run test:watch` during development to re-run tests on file changes.
+
+### Authentication
+
+All `/api/v1/*` endpoints expect an API key using the `Authorization` header with the `Bearer` scheme. Example:
+
+```bash
+curl -H 'Authorization: Bearer SANDBOX_KEY_123' http://localhost:9002/api/v1/dpp
+```
+
+Valid keys are configured via the `VALID_API_KEYS` environment variable. The `.env.example` file defines two sample keys:
+
+```bash
+VALID_API_KEYS=SANDBOX_KEY_123,PROD_KEY_456
+```
 
 ### Troubleshooting
 

--- a/src/app/api/v1/dpp/[productId]/compliance-summary/route.ts
+++ b/src/app/api/v1/dpp/[productId]/compliance-summary/route.ts
@@ -6,6 +6,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { MOCK_DPPS } from '@/data';
 import type { DigitalProductPassport } from '@/types/dpp';
+import { validateApiKey } from '@/middleware/apiKeyAuth';
 
 // Simplified function to determine overall status, similar to getOverallComplianceDetails
 const calculateOverallStatus = (dpp: DigitalProductPassport): string => {
@@ -39,6 +40,8 @@ export async function GET(
   { params }: { params: { productId: string } }
 ) {
   const productId = params.productId;
+  const auth = validateApiKey(request);
+  if (auth) return auth;
 
   // Conceptual API key authentication - skipped for mock
   // const authHeader = request.headers.get('Authorization');

--- a/src/app/api/v1/dpp/[productId]/lifecycle-events/route.ts
+++ b/src/app/api/v1/dpp/[productId]/lifecycle-events/route.ts
@@ -6,6 +6,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { MOCK_DPPS } from '@/data';
 import type { LifecycleEvent } from '@/types/dpp';
+import { validateApiKey } from '@/middleware/apiKeyAuth';
 
 interface AddLifecycleEventRequestBody {
   eventType?: string; // Matches 'type' in LifecycleEvent but using a clearer name for request
@@ -20,6 +21,8 @@ export async function POST(
   { params }: { params: { productId: string } }
 ) {
   const productId = params.productId;
+  const auth = validateApiKey(request);
+  if (auth) return auth;
   let requestBody: AddLifecycleEventRequestBody;
 
   try {

--- a/src/app/api/v1/dpp/[productId]/route.ts
+++ b/src/app/api/v1/dpp/[productId]/route.ts
@@ -6,6 +6,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { MOCK_DPPS } from '@/data';
 import type { DigitalProductPassport, CustomAttribute } from '@/types/dpp';
+import { validateApiKey } from '@/middleware/apiKeyAuth';
 
 interface UpdateDppRequestBody {
   productName?: string;
@@ -26,6 +27,8 @@ export async function GET(
   { params }: { params: { productId: string } }
 ) {
   const productId = params.productId;
+  const auth = validateApiKey(request);
+  if (auth) return auth;
 
   // Conceptually, API key authentication would happen here.
   // For this mock, we'll skip actual validation.
@@ -51,6 +54,8 @@ export async function PUT(
   { params }: { params: { productId: string } }
 ) {
   const productId = params.productId;
+  const auth = validateApiKey(request);
+  if (auth) return auth;
   let requestBody: UpdateDppRequestBody;
 
   try {
@@ -119,6 +124,8 @@ export async function DELETE(
   { params }: { params: { productId: string } }
 ) {
   const productId = params.productId;
+  const auth = validateApiKey(request);
+  if (auth) return auth;
 
   // Conceptual API key authentication
   // const authHeader = request.headers.get('Authorization');

--- a/src/app/api/v1/dpp/extend/[productId]/route.ts
+++ b/src/app/api/v1/dpp/extend/[productId]/route.ts
@@ -4,6 +4,7 @@
 
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { validateApiKey } from '@/middleware/apiKeyAuth';
 import { MOCK_DPPS } from '@/data';
 import type { DigitalProductPassport, DocumentReference } from '@/types/dpp';
 
@@ -21,6 +22,8 @@ export async function PATCH(
   { params }: { params: { productId: string } }
 ) {
   const productId = params.productId;
+  const auth = validateApiKey(request);
+  if (auth) return auth;
   let requestBody: ExtendDppRequestBody;
 
   try {

--- a/src/app/api/v1/dpp/graph/[productId]/route.ts
+++ b/src/app/api/v1/dpp/graph/[productId]/route.ts
@@ -4,6 +4,7 @@
 
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { validateApiKey } from '@/middleware/apiKeyAuth';
 import { MOCK_DPPS, MOCK_SUPPLIERS } from '@/data';
 import type { DigitalProductPassport, Supplier } from '@/types/dpp';
 
@@ -32,6 +33,8 @@ export async function GET(
   { params }: { params: { productId: string } }
 ) {
   const productId = params.productId;
+  const auth = validateApiKey(request);
+  if (auth) return auth;
 
   // Conceptual API key authentication - skipped for mock
   // const authHeader = request.headers.get('Authorization');

--- a/src/app/api/v1/dpp/history/[productId]/route.ts
+++ b/src/app/api/v1/dpp/history/[productId]/route.ts
@@ -4,6 +4,7 @@
 
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { validateApiKey } from '@/middleware/apiKeyAuth';
 import { MOCK_DPPS } from '@/data';
 import type { DigitalProductPassport, LifecycleEvent, Certification, EbsiVerificationDetails, HistoryEntry } from '@/types/dpp';
 
@@ -12,6 +13,8 @@ export async function GET(
   { params }: { params: { productId: string } }
 ) {
   const productId = params.productId;
+  const auth = validateApiKey(request);
+  if (auth) return auth;
 
   const product = MOCK_DPPS.find(dpp => dpp.id === productId);
 

--- a/src/app/api/v1/dpp/import/route.ts
+++ b/src/app/api/v1/dpp/import/route.ts
@@ -4,6 +4,7 @@
 
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { validateApiKey } from '@/middleware/apiKeyAuth';
 
 interface ImportDppRequestBody {
   fileType?: string; // e.g., "csv", "json", "api"
@@ -12,6 +13,8 @@ interface ImportDppRequestBody {
 }
 
 export async function POST(request: NextRequest) {
+  const auth = validateApiKey(request);
+  if (auth) return auth;
   let requestBody: ImportDppRequestBody;
 
   try {

--- a/src/app/api/v1/dpp/route.ts
+++ b/src/app/api/v1/dpp/route.ts
@@ -4,6 +4,7 @@
 
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { validateApiKey } from '@/middleware/apiKeyAuth';
 import { MOCK_DPPS } from '@/data';
 import type { DigitalProductPassport, CustomAttribute, DashboardFiltersState } from '@/types/dpp';
 
@@ -24,6 +25,8 @@ interface CreateDppRequestBody {
 }
 
 export async function POST(request: NextRequest) {
+  const auth = validateApiKey(request);
+  if (auth) return auth;
   let requestBody: CreateDppRequestBody;
   try {
     requestBody = await request.json();
@@ -102,6 +105,8 @@ export async function POST(request: NextRequest) {
 }
 
 export async function GET(request: NextRequest) {
+  const auth = validateApiKey(request);
+  if (auth) return auth;
   const { searchParams } = new URL(request.url);
 
   const status = searchParams.get('status') as DashboardFiltersState['status'] | null;

--- a/src/app/api/v1/dpp/status/[productId]/route.ts
+++ b/src/app/api/v1/dpp/status/[productId]/route.ts
@@ -6,12 +6,15 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { MOCK_DPPS } from '@/data';
 import type { DigitalProductPassport } from '@/types/dpp';
+import { validateApiKey } from '@/middleware/apiKeyAuth';
 
 export async function GET(
   request: NextRequest,
   { params }: { params: { productId: string } }
 ) {
   const productId = params.productId;
+  const auth = validateApiKey(request);
+  if (auth) return auth;
 
   // Conceptual API key authentication - skipped for mock
   // const authHeader = request.headers.get('Authorization');

--- a/src/app/api/v1/dpp/verify/[productId]/route.ts
+++ b/src/app/api/v1/dpp/verify/[productId]/route.ts
@@ -5,6 +5,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { MOCK_DPPS } from '@/data';
+import { validateApiKey } from '@/middleware/apiKeyAuth';
 
 // Request body is currently not used for this endpoint as productId comes from path.
 // interface VerifyDppRequestBody {
@@ -28,6 +29,9 @@ export async function POST(
   if (!productId || typeof productId !== 'string' || productId.trim() === '') {
     return NextResponse.json({ error: { code: 400, message: "Path parameter 'productId' is required and must be a non-empty string." } }, { status: 400 });
   }
+
+  const auth = validateApiKey(request);
+  if (auth) return auth;
   
   // Conceptual API key authentication - skipped for mock
   // const authHeader = request.headers.get('Authorization');

--- a/src/app/api/v1/qr/[productId]/route.ts
+++ b/src/app/api/v1/qr/[productId]/route.ts
@@ -1,12 +1,15 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import QRCode from 'qrcode';
+import { validateApiKey } from '@/middleware/apiKeyAuth';
 
 export async function GET(
   request: NextRequest,
   { params }: { params: { productId: string } }
 ) {
   const { productId } = params;
+  const auth = validateApiKey(request);
+  if (auth) return auth;
   try {
     const dataUrl = await QRCode.toDataURL(`/passport/${productId}`);
     const base64 = dataUrl.split(',')[1];

--- a/src/app/api/v1/qr/validate/route.ts
+++ b/src/app/api/v1/qr/validate/route.ts
@@ -6,12 +6,15 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { MOCK_DPPS } from '@/data';
 import type { DigitalProductPassport } from '@/types/dpp';
+import { validateApiKey } from '@/middleware/apiKeyAuth';
 
 interface QrValidateRequestBody {
   qrIdentifier?: string;
 }
 
 export async function POST(request: NextRequest) {
+  const auth = validateApiKey(request);
+  if (auth) return auth;
   let requestBody: QrValidateRequestBody;
   try {
     requestBody = await request.json();

--- a/src/middleware/apiKeyAuth.ts
+++ b/src/middleware/apiKeyAuth.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function validateApiKey(request: NextRequest): NextResponse | undefined {
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return NextResponse.json({ error: { code: 401, message: 'API key missing or invalid.' } }, { status: 401 });
+  }
+  const providedKey = authHeader.slice('Bearer '.length).trim();
+  const validKeysEnv = process.env.VALID_API_KEYS || '';
+  const validKeys = validKeysEnv.split(',').map(k => k.trim()).filter(Boolean);
+  if (!validKeys.includes(providedKey)) {
+    return NextResponse.json({ error: { code: 401, message: 'API key missing or invalid.' } }, { status: 401 });
+  }
+  return undefined;
+}

--- a/src/utils/__tests__/apiRoutesAuth.test.ts
+++ b/src/utils/__tests__/apiRoutesAuth.test.ts
@@ -1,0 +1,20 @@
+import { GET as listDpp } from '@/app/api/v1/dpp/route';
+import { POST as validateQr } from '@/app/api/v1/qr/validate/route';
+
+const makeRequest = (url: string, headers: Record<string, string> = {}, body?: any) => ({
+  url,
+  headers: new Headers(headers),
+  json: async () => body,
+} as any);
+
+describe('API routes authentication', () => {
+  it('returns 401 when Authorization header is missing', async () => {
+    const res = await listDpp(makeRequest('http://test'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when API key is invalid', async () => {
+    const res = await validateQr(makeRequest('http://test', { Authorization: 'Bearer BAD' }, { qrIdentifier: 'id' }));
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- add API key validation middleware
- secure API routes with API key check
- show how to use API keys in README and sample env file
- test routes return 401 for missing/invalid keys

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490acd5b50832abf584852ae3bd164