### PR TITLE
Add custody update endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -317,6 +317,63 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/dpp/custody/{productId}:
+    patch:
+      operationId: updateCustody
+      summary: Update chain of custody
+      description: Appends a new custodian entry to the DPP traceability information.
+      parameters:
+        - name: productId
+          in: path
+          required: true
+          description: The unique identifier of the DPP to update.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                did:
+                  type: string
+                  description: Decentralized identifier of the new custodian.
+                timestamp:
+                  type: string
+                  format: date-time
+                  description: Time of the custody transfer.
+                location:
+                  type: string
+                  nullable: true
+              required:
+                - did
+                - timestamp
+      responses:
+        '200':
+          description: Returns the updated DPP
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DigitalProductPassport'
+        '400':
+          description: Invalid input data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Product not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/v1/dpp/{productId}/lifecycle-events:
     post:
       operationId: addDppLifecycleEvent
@@ -1379,22 +1436,24 @@ paths:
           type: array
           nullable: true
           items:
-            type: object
-            properties:
-              stepName:
-                type: string
-              actorDid:
-                type: string
-                nullable: true
-              timestamp:
-                type: string
-                format: date-time
-              location:
-                type: string
-                nullable: true
-              transactionHash:
-                type: string
-                nullable: true
+            $ref: '#/components/schemas/SupplyChainStep'
+    SupplyChainStep:
+      type: object
+      properties:
+        stepName:
+          type: string
+        actorDid:
+          type: string
+          nullable: true
+        timestamp:
+          type: string
+          format: date-time
+        location:
+          type: string
+          nullable: true
+        transactionHash:
+          type: string
+          nullable: true
     VerifiableCredentialReference:
       type: object
       properties:

--- a/src/app/api/v1/dpp/custody/[productId]/route.ts
+++ b/src/app/api/v1/dpp/custody/[productId]/route.ts
@@ -1,0 +1,62 @@
+// --- File: src/app/api/v1/dpp/custody/[productId]/route.ts ---
+// Description: Endpoint to update chain of custody information for a DPP.
+
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { MOCK_DPPS } from '@/data';
+import type { SupplyChainStep, DigitalProductPassport } from '@/types/dpp';
+
+interface CustodyUpdateRequestBody {
+  did: string;
+  timestamp: string;
+  location?: string;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { productId: string } }
+) {
+  const productId = params.productId;
+  let requestBody: CustodyUpdateRequestBody;
+
+  try {
+    requestBody = await request.json();
+  } catch (error) {
+    return NextResponse.json({ error: { code: 400, message: 'Invalid JSON payload.' } }, { status: 400 });
+  }
+
+  const { did, timestamp, location } = requestBody;
+  if (!did || !timestamp) {
+    return NextResponse.json({ error: { code: 400, message: "Fields 'did' and 'timestamp' are required." } }, { status: 400 });
+  }
+
+  const productIndex = MOCK_DPPS.findIndex(dpp => dpp.id === productId);
+
+  await new Promise(resolve => setTimeout(resolve, 150));
+
+  if (productIndex === -1) {
+    return NextResponse.json({ error: { code: 404, message: `Product with ID ${productId} not found.` } }, { status: 404 });
+  }
+
+  const product = MOCK_DPPS[productIndex];
+  if (!product.traceability) {
+    product.traceability = {};
+  }
+  if (!product.traceability.supplyChainSteps) {
+    product.traceability.supplyChainSteps = [];
+  }
+
+  const newStep: SupplyChainStep = {
+    stepName: 'Custody Update',
+    actorDid: did,
+    timestamp,
+    ...(location && { location }),
+  };
+
+  product.traceability.supplyChainSteps.push(newStep);
+  product.metadata.last_updated = new Date().toISOString();
+
+  MOCK_DPPS[productIndex] = product as DigitalProductPassport;
+
+  return NextResponse.json(product);
+}

--- a/src/app/api/v1/dpp/custody/__tests__/custodyRoute.test.ts
+++ b/src/app/api/v1/dpp/custody/__tests__/custodyRoute.test.ts
@@ -1,0 +1,28 @@
+import { PATCH } from '../[productId]/route';
+import { MOCK_DPPS } from '@/data';
+
+describe('custody PATCH route', () => {
+  it('appends custody step and returns updated DPP', async () => {
+    const productId = MOCK_DPPS[0].id;
+    const initialLength = MOCK_DPPS[0].traceability?.supplyChainSteps?.length || 0;
+
+    const body = {
+      did: 'did:example:newCustodian',
+      timestamp: '2024-08-01T12:00:00Z',
+      location: 'Warehouse Z'
+    };
+
+    const mockRequest = { json: jest.fn().mockResolvedValue(body) } as any;
+
+    const response = await PATCH(mockRequest, { params: { productId } });
+    const data = await response.json();
+
+    expect(data.traceability.supplyChainSteps.length).toBe(initialLength + 1);
+    const added = data.traceability.supplyChainSteps[initialLength];
+    expect(added.actorDid).toBe(body.did);
+    expect(added.timestamp).toBe(body.timestamp);
+    expect(added.location).toBe(body.location);
+
+    expect(MOCK_DPPS[0].traceability?.supplyChainSteps?.length).toBe(initialLength + 1);
+  });
+});

--- a/src/types/dpp/Product.ts
+++ b/src/types/dpp/Product.ts
@@ -7,16 +7,18 @@ import type { Certification, EbsiVerificationDetails, SimpleCertification, Produ
 export const USER_PRODUCTS_LOCAL_STORAGE_KEY = 'norruvaUserProducts';
 export const USER_SUPPLIERS_LOCAL_STORAGE_KEY = 'norruvaUserSuppliers';
 
+export interface SupplyChainStep {
+  stepName: string;
+  actorDid?: string;
+  timestamp: string;
+  location?: string;
+  transactionHash?: string;
+}
+
 export interface TraceabilityInfo {
   batchId?: string;
   originCountry?: string;
-  supplyChainSteps?: Array<{
-    stepName: string;
-    actorDid?: string;
-    timestamp: string;
-    location?: string;
-    transactionHash?: string;
-  }>;
+  supplyChainSteps?: SupplyChainStep[];
 }
 
 export interface VerifiableCredentialReference {


### PR DESCRIPTION
## Summary
- extend API spec with PATCH `/api/v1/dpp/custody/{productId}`
- define `SupplyChainStep` and update `TraceabilityInfo`
- implement custody PATCH handler using mock data
- test custody PATCH logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490acebf7c832ab513845415d45782