### PR TITLE
Add transfer ownership endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -714,6 +714,70 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+      '500':
+        description: Internal server error.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/dpp/transfer-ownership/{productId}:
+    post:
+      operationId: transferDppOwnership
+      summary: Transfer Ownership of a Digital Product Passport
+      description: Updates ownership information for the specified DPP.
+      parameters:
+        - name: productId
+          in: path
+          required: true
+          description: The unique identifier of the product.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                newOwner:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    did:
+                      type: string
+                      nullable: true
+                transferTimestamp:
+                  type: string
+                  format: date-time
+              required:
+                - newOwner
+                - transferTimestamp
+      responses:
+        '200':
+          description: Ownership transferred successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DigitalProductPassport'
+        '400':
+          description: Invalid input data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Product not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal server error.
           content:

--- a/src/app/api/__tests__/transferOwnership.test.ts
+++ b/src/app/api/__tests__/transferOwnership.test.ts
@@ -1,0 +1,42 @@
+import { POST } from '../v1/dpp/transfer-ownership/[productId]/route';
+import { MOCK_DPPS } from '@/data';
+import { NextRequest } from 'next/server';
+
+describe('POST /api/v1/dpp/transfer-ownership/[productId]', () => {
+  it('updates manufacturer and traceability for existing product', async () => {
+    const productId = 'DPP001';
+    const payload = {
+      newOwner: { name: 'New Owner Inc', did: 'did:example:new' },
+      transferTimestamp: '2024-08-01T12:00:00Z',
+    };
+    const request = new NextRequest(new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    const response = await POST(request, { params: { productId } });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.manufacturer.name).toBe('New Owner Inc');
+    const lastStep = data.traceability.supplyChainSteps[data.traceability.supplyChainSteps.length - 1];
+    expect(lastStep).toEqual(
+      expect.objectContaining({
+        stepName: 'Ownership Transfer',
+        actorDid: 'did:example:new',
+        timestamp: '2024-08-01T12:00:00Z',
+      })
+    );
+    expect(MOCK_DPPS.find(dpp => dpp.id === productId)?.manufacturer?.name).toBe('New Owner Inc');
+  });
+
+  it('returns 404 for unknown product', async () => {
+    const request = new NextRequest(new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ newOwner: { name: 'Foo' }, transferTimestamp: '2024-08-01T12:00:00Z' }),
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    const response = await POST(request, { params: { productId: 'BAD_ID' } });
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/app/api/v1/dpp/transfer-ownership/[productId]/route.ts
+++ b/src/app/api/v1/dpp/transfer-ownership/[productId]/route.ts
@@ -1,0 +1,66 @@
+// --- File: src/app/api/v1/dpp/transfer-ownership/[productId]/route.ts ---
+// Description: Conceptual API endpoint to transfer ownership of a DPP.
+
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { MOCK_DPPS } from '@/data';
+import type { DigitalProductPassport } from '@/types/dpp';
+
+interface TransferOwnershipRequestBody {
+  newOwner?: {
+    name?: string;
+    did?: string;
+  };
+  transferTimestamp?: string;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { productId: string } }
+) {
+  const productId = params.productId;
+  let requestBody: TransferOwnershipRequestBody;
+
+  try {
+    requestBody = await request.json();
+  } catch (error) {
+    return NextResponse.json({ error: { code: 400, message: "Invalid JSON payload." } }, { status: 400 });
+  }
+
+  const { newOwner, transferTimestamp } = requestBody;
+
+  if (!newOwner?.name || !transferTimestamp) {
+    return NextResponse.json({ error: { code: 400, message: "Fields 'newOwner.name' and 'transferTimestamp' are required." } }, { status: 400 });
+  }
+
+  const productIndex = MOCK_DPPS.findIndex(dpp => dpp.id === productId);
+
+  // Simulate API delay
+  await new Promise(resolve => setTimeout(resolve, 150));
+
+  if (productIndex === -1) {
+    return NextResponse.json({ error: { code: 404, message: `Product with ID ${productId} not found.` } }, { status: 404 });
+  }
+
+  const product: DigitalProductPassport = { ...MOCK_DPPS[productIndex] };
+
+  product.manufacturer = { ...(product.manufacturer || {}), name: newOwner.name, ...(newOwner.did ? { did: newOwner.did } : {}) };
+
+  if (!product.traceability) {
+    product.traceability = { supplyChainSteps: [] };
+  }
+  if (!product.traceability.supplyChainSteps) {
+    product.traceability.supplyChainSteps = [];
+  }
+  product.traceability.supplyChainSteps.push({
+    stepName: 'Ownership Transfer',
+    actorDid: newOwner.did,
+    timestamp: transferTimestamp,
+  });
+
+  product.metadata.last_updated = new Date().toISOString();
+
+  MOCK_DPPS[productIndex] = product;
+
+  return NextResponse.json(product);
+}


### PR DESCRIPTION
## Summary
- extend OpenAPI spec with `/api/v1/dpp/transfer-ownership/{productId}`
- implement handler for ownership transfer
- add tests covering new route behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490af55544832a910dcabe0ec25b57