### PR TITLE
Add DPP anchor API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -541,6 +541,61 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/dpp/anchor/{productId}:
+    post:
+      operationId: anchorDpp
+      summary: Anchor a Digital Product Passport
+      description: Creates a blockchain anchor for the specified DPP.
+      parameters:
+        - name: productId
+          in: path
+          required: true
+          description: The unique identifier of the product to anchor.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                platform:
+                  type: string
+                  description: Blockchain or anchoring platform name.
+              required:
+                - platform
+      responses:
+        '200':
+          description: DPP anchored successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DigitalProductPassport'
+        '400':
+          description: Invalid input data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Product not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/v1/dpp/history/{productId}:
     get:
       operationId: getDppHistoryById

--- a/src/app/api/v1/dpp/anchor/[productId]/route.ts
+++ b/src/app/api/v1/dpp/anchor/[productId]/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { MOCK_DPPS } from '@/data';
+import type { DigitalProductPassport } from '@/types/dpp';
+
+interface AnchorDppRequestBody {
+  platform: string;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { productId: string } }
+) {
+  const productId = params.productId;
+  let requestBody: AnchorDppRequestBody;
+
+  try {
+    requestBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: { code: 400, message: 'Invalid JSON payload.' } }, { status: 400 });
+  }
+
+  if (!requestBody.platform || requestBody.platform.trim() === '') {
+    return NextResponse.json({ error: { code: 400, message: "Field 'platform' is required." } }, { status: 400 });
+  }
+
+  const index = MOCK_DPPS.findIndex(dpp => dpp.id === productId);
+
+  await new Promise(resolve => setTimeout(resolve, 150));
+
+  if (index === -1) {
+    return NextResponse.json({ error: { code: 404, message: `Product with ID ${productId} not found.` } }, { status: 404 });
+  }
+
+  const anchorHash = `0xmockAnchor${Date.now().toString(16)}`;
+
+  const updated: DigitalProductPassport = {
+    ...MOCK_DPPS[index],
+    blockchainIdentifiers: {
+      ...(MOCK_DPPS[index].blockchainIdentifiers || {}),
+      platform: requestBody.platform,
+      anchorTransactionHash: anchorHash,
+    },
+    metadata: {
+      ...MOCK_DPPS[index].metadata,
+      last_updated: new Date().toISOString(),
+    },
+  };
+
+  MOCK_DPPS[index] = updated;
+
+  return NextResponse.json(updated);
+}

--- a/src/types/dpp/Product.ts
+++ b/src/types/dpp/Product.ts
@@ -327,3 +327,9 @@ export interface DisplayableProduct {
   blockchainIdentifiers?: DigitalProductPassport['blockchainIdentifiers'];
 }
 
+export interface AnchorResult {
+  productId: string;
+  anchorTransactionHash: string;
+  platform?: string;
+}
+

--- a/src/utils/__tests__/anchorRoute.test.ts
+++ b/src/utils/__tests__/anchorRoute.test.ts
@@ -1,0 +1,25 @@
+import { POST } from '../../app/api/v1/dpp/anchor/[productId]/route';
+import { MOCK_DPPS } from '@/data';
+
+function createRequest(body: any) {
+  return new Request('http://test', { method: 'POST', body: JSON.stringify(body) });
+}
+
+describe('anchor route', () => {
+  it('anchors an existing product', async () => {
+    const res = await POST(createRequest({ platform: 'TestChain' }) as any, { params: { productId: 'DPP001' } });
+    const data = await res.json();
+    expect(data.blockchainIdentifiers.anchorTransactionHash).toBeDefined();
+    expect(data.blockchainIdentifiers.platform).toBe('TestChain');
+  });
+
+  it('returns 400 when platform missing', async () => {
+    const res = await POST(createRequest({}) as any, { params: { productId: 'DPP001' } });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for unknown product', async () => {
+    const res = await POST(createRequest({ platform: 'Chain' }) as any, { params: { productId: 'UNKNOWN' } });
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- define `POST /api/v1/dpp/anchor/{productId}` in openapi spec
- add API route handler to simulate anchoring and update mock data
- export `AnchorResult` interface
- test anchor route behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490af6693c832a8e88e193f9fd39b6