### PR TITLE
Add credential endpoint and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ curl -H 'Authorization: Bearer <API_KEY>' \
 
 The `verifiableCredentials` array in the response contains credential objects that wallets can verify. These calls can also be executed via the in-app API playground under **Developer Portal → API Reference**.
 
+### Fetching the Credential Directly
+
+Use the dedicated endpoint to retrieve a single verifiable credential JSON:
+
+```bash
+curl -H 'Authorization: Bearer <API_KEY>' \
+  https://api.example.com/api/v1/dpp/{productId}/credential
+```
+
+
 ## Getting Started
 
 ### Prerequisites

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -488,6 +488,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/dpp/{productId}/credential:
+    get:
+      operationId: getDppCredential
+      summary: Retrieve Verifiable Credential for a DPP
+      description: Returns a verifiable credential (VC) representation of the Digital Product Passport for the specified product.
+      parameters:
+        - name: productId
+          in: path
+          required: true
+          description: The unique identifier of the product.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DppCredential'
+        '401':
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Product not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/v1/dpp/verify/{productId}:
     post:
       operationId: verifyDppById
@@ -1421,6 +1458,31 @@ paths:
           nullable: true
         verificationMethod:
           type: string
+          nullable: true
+    DppCredential:
+      type: object
+      properties:
+        "@context":
+          type: array
+          items:
+            type: string
+        id:
+          type: string
+        type:
+          type: array
+          items:
+            type: string
+        issuer:
+          type: string
+        issuanceDate:
+          type: string
+          format: date-time
+        credentialSubject:
+          type: object
+          additionalProperties: true
+        proof:
+          type: object
+          additionalProperties: true
           nullable: true
     CustomAttribute:
       type: object

--- a/src/app/api/v1/dpp/[productId]/credential/__tests__/route.test.ts
+++ b/src/app/api/v1/dpp/[productId]/credential/__tests__/route.test.ts
@@ -1,0 +1,23 @@
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (data: any, init?: { status?: number }) => ({ data, status: init?.status || 200 }),
+  },
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/v1/dpp/[productId]/credential', () => {
+  it('returns a verifiable credential structure', async () => {
+    const res = await GET({} as any, { params: { productId: 'DPP001' } });
+    expect(res.status).toBe(200);
+    expect(res.data).toHaveProperty('@context');
+    expect(res.data).toHaveProperty('credentialSubject');
+    expect(res.data.type).toContain('VerifiableCredential');
+  });
+
+  it('returns 404 for unknown product', async () => {
+    const res = await GET({} as any, { params: { productId: 'UNKNOWN' } });
+    expect(res.status).toBe(404);
+    expect(res.data.error).toBeDefined();
+  });
+});

--- a/src/app/api/v1/dpp/[productId]/credential/route.ts
+++ b/src/app/api/v1/dpp/[productId]/credential/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { MOCK_DPPS } from '@/data';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { productId: string } }
+) {
+  const productId = params.productId;
+  const product = MOCK_DPPS.find(dpp => dpp.id === productId);
+
+  await new Promise(resolve => setTimeout(resolve, 100));
+
+  if (!product) {
+    return NextResponse.json({ error: { code: 404, message: `Product with ID ${productId} not found.` } }, { status: 404 });
+  }
+
+  const now = new Date().toISOString();
+
+  const credential = {
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    id: `urn:uuid:${productId}`,
+    type: ["VerifiableCredential", "DigitalProductPassportCredential"],
+    issuer: product.manufacturer?.did || "did:example:norruva",
+    issuanceDate: now,
+    credentialSubject: {
+      id: product.id,
+      productName: product.productName,
+      category: product.category,
+      manufacturer: product.manufacturer?.name,
+      modelNumber: product.modelNumber,
+      gtin: product.gtin,
+    },
+    proof: {
+      type: "Ed25519Signature2018",
+      created: now,
+      proofPurpose: "assertionMethod",
+      verificationMethod: "did:example:norruva#key-1",
+      jws: "eyJhbGciOiJFZERTQSJ9..mock",
+    },
+  };
+
+  return NextResponse.json(credential);
+}


### PR DESCRIPTION
## Summary
- specify GET /api/v1/dpp/{productId}/credential in OpenAPI spec
- implement route returning mock VC for a DPP
- document new endpoint usage in README
- add Jest tests for credential handler

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490ae8609c832abb63dd27954c3c29