### PR TITLE
Add service worker and PWA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,15 @@ This will start the Next.js application, usually on `http://localhost:9002` (as 
 
 Open `http://localhost:9002` in your browser to view the application.
 
+### Installing as a PWA
+
+The application includes a service worker and web app manifest. When running in
+development (`npm run dev`) or production, you can install it like a native app:
+
+1. Open the site in Chrome or another PWA-compatible browser.
+2. Click the browser's **Install** icon or choose **Add to Home Screen**.
+3. Launch the app from your home screen to use it in standalone mode.
+
 ### Running Tests
 
 Run the unit tests with:

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "Norruva Digital Product Passport",
+  "short_name": "Norruva DPP",
+  "description": "Manage and view digital product passports",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,50 @@
+const CACHE_NAME = 'norruva-dpp-cache-v1';
+const STATIC_ASSETS = [
+  '/openapi.yaml',
+  '/favicon.ico',
+  '/manifest.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+    ))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  if (url.pathname.startsWith('/passport/')) {
+    event.respondWith(
+      fetch(request)
+        .then(response => {
+          const respClone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(request, respClone));
+          return response;
+        })
+        .catch(() => caches.match(request))
+    );
+    return;
+  }
+
+  if (url.pathname === '/openapi.yaml' || request.destination === 'image') {
+    event.respondWith(
+      caches.match(request).then(cached => {
+        return cached || fetch(request).then(resp => {
+          const respClone = resp.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(request, respClone));
+          return resp;
+        });
+      })
+    );
+  }
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { Toaster } from "@/components/ui/toaster"
 import { RoleProvider } from '@/contexts/RoleContext'; // Import RoleProvider
 import { SkipToContent } from '@/components/layout/SkipToContent'
+import ServiceWorkerRegister from '@/components/ServiceWorkerRegister';
 
 export const metadata: Metadata = {
   title: 'Norruva Digital Product Passport',
@@ -29,6 +30,7 @@ export default function RootLayout({
       </head>
       <body className="font-body antialiased">
         <SkipToContent />
+        <ServiceWorkerRegister />
         <RoleProvider> {/* RoleProvider now wraps all children at the root level */}
           {children}
         </RoleProvider>

--- a/src/components/ServiceWorkerRegister.tsx
+++ b/src/components/ServiceWorkerRegister.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useEffect } from 'react';
+import { registerServiceWorker } from '@/utils/registerServiceWorker';
+
+export default function ServiceWorkerRegister() {
+  useEffect(() => {
+    registerServiceWorker();
+  }, []);
+
+  return null;
+}

--- a/src/utils/__tests__/serviceWorkerRegistration.test.ts
+++ b/src/utils/__tests__/serviceWorkerRegistration.test.ts
@@ -1,0 +1,14 @@
+import { registerServiceWorker } from '../registerServiceWorker';
+
+describe('registerServiceWorker', () => {
+  it('registers sw when available', () => {
+    const registerMock = jest.fn();
+    Object.defineProperty(window.navigator, 'serviceWorker', {
+      value: { register: registerMock },
+      configurable: true,
+    });
+    registerServiceWorker();
+    window.dispatchEvent(new Event('load'));
+    expect(registerMock).toHaveBeenCalledWith('/sw.js');
+  });
+});

--- a/src/utils/registerServiceWorker.ts
+++ b/src/utils/registerServiceWorker.ts
@@ -1,0 +1,7 @@
+export function registerServiceWorker() {
+  if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('/sw.js');
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- implement custom service worker caching passport pages and static assets
- create web app manifest for installation
- register the service worker on the client and add test
- wire the registration component in the root layout
- document PWA installation steps in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490e1e5bec832a9bae62e946a27732