### PR TITLE
Add custody update endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ curl -X PATCH https://api.example.com/api/v1/dpp/extend/{productId} \
       }'
 ```
 
+### Updating Chain of Custody
+
+Append a new supply chain step using `PATCH /api/v1/dpp/custody/{productId}`:
+
+```bash
+curl -X PATCH https://api.example.com/api/v1/dpp/custody/{productId} \
+  -H 'Authorization: Bearer <API_KEY>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "stepName": "Handed to Distributor",
+        "actorDid": "did:example:distributor",
+        "timestamp": "2024-08-01T12:00:00Z",
+        "location": "Warehouse Z",
+        "transactionHash": "0xabc123"
+      }'
+```
+
 ### Retrieving a Verifiable Credential
 
 Fetch the DPP to obtain associated verifiable credentials that can be imported into digital wallets:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -336,18 +336,23 @@ paths:
             schema:
               type: object
               properties:
-                did:
+                stepName:
                   type: string
-                  description: Decentralized identifier of the new custodian.
+                actorDid:
+                  type: string
+                  description: Decentralized identifier of the actor.
                 timestamp:
                   type: string
                   format: date-time
-                  description: Time of the custody transfer.
                 location:
                   type: string
                   nullable: true
+                transactionHash:
+                  type: string
+                  nullable: true
               required:
-                - did
+                - stepName
+                - actorDid
                 - timestamp
       responses:
         '200':

--- a/src/app/api/v1/dpp/custody/[productId]/route.ts
+++ b/src/app/api/v1/dpp/custody/[productId]/route.ts
@@ -7,9 +7,11 @@ import { MOCK_DPPS } from '@/data';
 import type { SupplyChainStep, DigitalProductPassport } from '@/types/dpp';
 
 interface CustodyUpdateRequestBody {
-  did: string;
+  stepName: string;
+  actorDid: string;
   timestamp: string;
   location?: string;
+  transactionHash?: string;
 }
 
 export async function PATCH(
@@ -25,9 +27,9 @@ export async function PATCH(
     return NextResponse.json({ error: { code: 400, message: 'Invalid JSON payload.' } }, { status: 400 });
   }
 
-  const { did, timestamp, location } = requestBody;
-  if (!did || !timestamp) {
-    return NextResponse.json({ error: { code: 400, message: "Fields 'did' and 'timestamp' are required." } }, { status: 400 });
+  const { stepName, actorDid, timestamp, location, transactionHash } = requestBody;
+  if (!stepName || !actorDid || !timestamp) {
+    return NextResponse.json({ error: { code: 400, message: "Fields 'stepName', 'actorDid' and 'timestamp' are required." } }, { status: 400 });
   }
 
   const productIndex = MOCK_DPPS.findIndex(dpp => dpp.id === productId);
@@ -47,10 +49,11 @@ export async function PATCH(
   }
 
   const newStep: SupplyChainStep = {
-    stepName: 'Custody Update',
-    actorDid: did,
+    stepName,
+    actorDid,
     timestamp,
-    ...(location && { location }),
+    location: location || '',
+    transactionHash: transactionHash || '',
   };
 
   product.traceability.supplyChainSteps.push(newStep);

--- a/src/app/api/v1/dpp/custody/__tests__/custodyRoute.test.ts
+++ b/src/app/api/v1/dpp/custody/__tests__/custodyRoute.test.ts
@@ -7,9 +7,11 @@ describe('custody PATCH route', () => {
     const initialLength = MOCK_DPPS[0].traceability?.supplyChainSteps?.length || 0;
 
     const body = {
-      did: 'did:example:newCustodian',
+      stepName: 'Custody Transfer',
+      actorDid: 'did:example:newCustodian',
       timestamp: '2024-08-01T12:00:00Z',
-      location: 'Warehouse Z'
+      location: 'Warehouse Z',
+      transactionHash: '0xnewhash'
     };
 
     const mockRequest = { json: jest.fn().mockResolvedValue(body) } as any;
@@ -19,9 +21,10 @@ describe('custody PATCH route', () => {
 
     expect(data.traceability.supplyChainSteps.length).toBe(initialLength + 1);
     const added = data.traceability.supplyChainSteps[initialLength];
-    expect(added.actorDid).toBe(body.did);
+    expect(added.actorDid).toBe(body.actorDid);
     expect(added.timestamp).toBe(body.timestamp);
     expect(added.location).toBe(body.location);
+    expect(added.transactionHash).toBe(body.transactionHash);
 
     expect(MOCK_DPPS[0].traceability?.supplyChainSteps?.length).toBe(initialLength + 1);
   });

--- a/src/data/mockDpps.ts
+++ b/src/data/mockDpps.ts
@@ -53,6 +53,17 @@ export const MOCK_DPPS: DigitalProductPassport[] = [
       { name: "User Manual v1.2", url: "#manual_v1.2.pdf", type: "User Manual", addedTimestamp: "2024-01-15T00:00:00Z" },
       { name: "Warranty Card", url: "#warranty.pdf", type: "Warranty", addedTimestamp: "2024-01-15T00:00:00Z" },
     ],
+    traceability: {
+      supplyChainSteps: [
+        {
+          stepName: 'Manufactured',
+          actorDid: 'did:example:greentech',
+          timestamp: '2024-01-15T00:00:00Z',
+          location: 'Factory A',
+          transactionHash: '0xstep1'
+        }
+      ]
+    },
     supplyChainLinks: [
       { supplierId: "SUP001", suppliedItem: "Compressor Unit XJ-500", notes: "Primary compressor supplier for EU market. Audited for ethical sourcing." },
       { supplierId: "SUP002", suppliedItem: "Recycled Steel Panels (70%)", notes: "Certified post-consumer recycled content." }
@@ -85,6 +96,17 @@ export const MOCK_DPPS: DigitalProductPassport[] = [
       {id: "cert3", name: "GOTS", issuer: "Control Union", issueDate: "2024-02-20", expiryDate: "2025-02-19", documentUrl: "#gots", standard: "Global Organic Textile Standard 6.0"},
     ],
     documents: [],
+    traceability: {
+      supplyChainSteps: [
+        {
+          stepName: 'Manufactured',
+          actorDid: 'did:example:ecothreads',
+          timestamp: '2024-03-05T00:00:00Z',
+          location: 'Factory B',
+          transactionHash: '0xstep2'
+        }
+      ]
+    },
     supplyChainLinks: [
        { supplierId: "SUP003", suppliedItem: "Organic Cotton Yarn", notes: "GOTS Certified Supplier for all global production." }
     ]
@@ -105,9 +127,20 @@ export const MOCK_DPPS: DigitalProductPassport[] = [
     consumerScans: 2100,
      productDetails: { description: "A recycled phone case."},
      blockchainIdentifiers: { platform: "OtherChain", anchorTransactionHash: "0x789polymerAnchorHash000333"},
-     documents: [],
-     supplyChainLinks: [],
-     ebsiVerification: { status: "not_verified", lastChecked: "2024-07-23T00:00:00Z"},
+    documents: [],
+    traceability: {
+      supplyChainSteps: [
+        {
+          stepName: 'Manufactured',
+          actorDid: 'did:example:recaseit',
+          timestamp: '2024-04-15T00:00:00Z',
+          location: 'Factory C',
+          transactionHash: '0xstep3'
+        }
+      ]
+    },
+    supplyChainLinks: [],
+    ebsiVerification: { status: "not_verified", lastChecked: "2024-07-23T00:00:00Z"},
   },
   {
     id: "DPP004",
@@ -124,6 +157,17 @@ export const MOCK_DPPS: DigitalProductPassport[] = [
     consumerScans: 850,
     productDetails: { description: "A modular sofa."},
     documents: [],
+    traceability: {
+      supplyChainSteps: [
+        {
+          stepName: 'Manufactured',
+          actorDid: 'did:example:comfyliving',
+          timestamp: '2023-12-10T00:00:00Z',
+          location: 'Factory D',
+          transactionHash: '0xstep4'
+        }
+      ]
+    },
     supplyChainLinks: [],
     ebsiVerification: { status: "error", lastChecked: "2024-07-19T00:00:00Z", message: "Connection timeout to EBSI node."},
   },
@@ -160,6 +204,17 @@ export const MOCK_DPPS: DigitalProductPassport[] = [
       {id: "cert_bat_01", name: "UN 38.3 Transport Test", issuer: "TestCert Ltd.", issueDate: "2024-07-01", documentUrl: "#", transactionHash: "0xcertAnchorBat1", standard: "UN Manual of Tests and Criteria, Part III, subsection 38.3"}
     ],
     documents: [],
+    traceability: {
+      supplyChainSteps: [
+        {
+          stepName: 'Manufactured',
+          actorDid: 'did:example:powervolt',
+          timestamp: '2024-05-10T00:00:00Z',
+          location: 'Factory E',
+          transactionHash: '0xstep5'
+        }
+      ]
+    },
     blockchainIdentifiers: { platform: "BatteryChain", anchorTransactionHash: "0xevBatteryAnchorHash555AAA"},
     supplyChainLinks: []
   },


### PR DESCRIPTION
## Summary
- add `SupplyChainStep` typing for supply-chain steps
- seed mock DPPs with basic supplyChainSteps data
- implement custody PATCH endpoint for adding supply chain steps
- document new endpoint and example usage
- test that custody PATCH stores a new supply chain step

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490e1c677c832aa4afa5caf20d8f29