### PR TITLE
Add API route tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ Run the unit tests with:
 npm test
 ```
 
+The suite now includes API route tests located in `src/app/api/__tests__`. These
+cover common success and failure cases for the DPP and QR validation endpoints.
+
 
 Use `npm run test:watch` during development to re-run tests on file changes.
 

--- a/src/app/api/__tests__/dppByIdRoute.test.ts
+++ b/src/app/api/__tests__/dppByIdRoute.test.ts
@@ -1,0 +1,36 @@
+import { GET } from '../v1/dpp/[productId]/route';
+import { MOCK_DPPS } from '@/data';
+import { MOCK_DPPS as ORIGINAL_DPPS } from '@/data/mockDpps';
+import { NextRequest } from 'next/server';
+
+beforeEach(() => {
+  process.env.VALID_API_KEYS = 'SANDBOX_KEY_123';
+  MOCK_DPPS.length = 0;
+  ORIGINAL_DPPS.forEach(d => MOCK_DPPS.push(JSON.parse(JSON.stringify(d))));
+});
+
+describe('/api/v1/dpp/[productId] route', () => {
+  it('returns the product when it exists', async () => {
+    const req = new NextRequest(new Request('http://test', {
+      headers: { Authorization: 'Bearer SANDBOX_KEY_123' }
+    }));
+    const res = await GET(req, { params: { productId: 'DPP001' } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.id).toBe('DPP001');
+  });
+
+  it('returns 404 for unknown product', async () => {
+    const req = new NextRequest(new Request('http://test', {
+      headers: { Authorization: 'Bearer SANDBOX_KEY_123' }
+    }));
+    const res = await GET(req, { params: { productId: 'UNKNOWN' } });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 401 when API key missing', async () => {
+    const req = new NextRequest(new Request('http://test'));
+    const res = await GET(req, { params: { productId: 'DPP001' } });
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/__tests__/dppRoute.test.ts
+++ b/src/app/api/__tests__/dppRoute.test.ts
@@ -1,0 +1,53 @@
+import { POST, GET } from '../v1/dpp/route';
+import { MOCK_DPPS } from '@/data';
+import { MOCK_DPPS as ORIGINAL_DPPS } from '@/data/mockDpps';
+import { NextRequest } from 'next/server';
+
+beforeEach(() => {
+  process.env.VALID_API_KEYS = 'SANDBOX_KEY_123';
+  MOCK_DPPS.length = 0;
+  ORIGINAL_DPPS.forEach(d => MOCK_DPPS.push(JSON.parse(JSON.stringify(d))));
+});
+
+describe('/api/v1/dpp route', () => {
+  it('creates a new DPP when payload is valid', async () => {
+    const body = { productName: 'Test Prod', category: 'TestCat' };
+    const req = new NextRequest(new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer SANDBOX_KEY_123' }
+    }));
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.productName).toBe('Test Prod');
+    expect(MOCK_DPPS.some(d => d.id === data.id)).toBe(true);
+  });
+
+  it('returns 400 when required fields missing', async () => {
+    const req = new NextRequest(new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ category: 'TestCat' }),
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer SANDBOX_KEY_123' }
+    }));
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('lists DPPs with valid API key', async () => {
+    const req = new NextRequest(new Request('http://test?status=published', {
+      headers: { Authorization: 'Bearer SANDBOX_KEY_123' }
+    }));
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data.data)).toBe(true);
+    expect(data.filtersApplied.status).toBe('published');
+  });
+
+  it('returns 401 when API key missing', async () => {
+    const req = new NextRequest(new Request('http://test'));
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/__tests__/qrValidateRoute.test.ts
+++ b/src/app/api/__tests__/qrValidateRoute.test.ts
@@ -1,0 +1,46 @@
+import { POST } from '../v1/qr/validate/route';
+import { MOCK_DPPS } from '@/data';
+import { MOCK_DPPS as ORIGINAL_DPPS } from '@/data/mockDpps';
+import { NextRequest } from 'next/server';
+
+beforeEach(() => {
+  process.env.VALID_API_KEYS = 'SANDBOX_KEY_123';
+  MOCK_DPPS.length = 0;
+  ORIGINAL_DPPS.forEach(d => MOCK_DPPS.push(JSON.parse(JSON.stringify(d))));
+});
+
+describe('/api/v1/qr/validate route', () => {
+  it('returns product summary for valid qrIdentifier', async () => {
+    const body = { qrIdentifier: 'DPP001' };
+    const req = new NextRequest(new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer SANDBOX_KEY_123' }
+    }));
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.productId).toBe('DPP001');
+  });
+
+  it('returns 404 for unknown qrIdentifier', async () => {
+    const body = { qrIdentifier: 'UNKNOWN' };
+    const req = new NextRequest(new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer SANDBOX_KEY_123' }
+    }));
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when qrIdentifier missing', async () => {
+    const req = new NextRequest(new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({}),
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer SANDBOX_KEY_123' }
+    }));
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `/api/v1/dpp` routes
- add tests for `/api/v1/dpp/[productId]` routes
- add tests for `/api/v1/qr/validate`
- document API route tests in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490e1c4d38832aacbdc1a5c8c320b2