### PR TITLE
Add API key config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ GOOGLE_API_KEY=
 # Path to Google Cloud service account credentials (optional)
 GOOGLE_APPLICATION_CREDENTIALS=
 
-# Comma-separated list of valid API keys used by the API middleware
+# Comma-separated list of valid API keys used by the API middleware.
+# These values populate the `API_KEYS` array in `src/config/auth.ts`.
 VALID_API_KEYS=SANDBOX_KEY_123,PROD_KEY_456
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ All `/api/v1/*` endpoints expect an API key using the `Authorization` header wit
 curl -H 'Authorization: Bearer SANDBOX_KEY_123' http://localhost:9002/api/v1/dpp
 ```
 
-Valid keys are configured via the `VALID_API_KEYS` environment variable. The `.env.example` file defines two sample keys:
+Valid keys are configured via the `VALID_API_KEYS` environment variable. This should be a comma-separated list of keys. The values are loaded at runtime by `src/config/auth.ts` as the `API_KEYS` array. The `.env.example` file defines two sample keys:
 
 ```bash
 VALID_API_KEYS=SANDBOX_KEY_123,PROD_KEY_456

--- a/src/config/auth.ts
+++ b/src/config/auth.ts
@@ -1,0 +1,4 @@
+export const API_KEYS: string[] = (process.env.VALID_API_KEYS || '')
+  .split(',')
+  .map(k => k.trim())
+  .filter(Boolean);

--- a/src/middleware/apiKeyAuth.ts
+++ b/src/middleware/apiKeyAuth.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { API_KEYS } from '@/config/auth';
 
 export function validateApiKey(request: NextRequest): NextResponse | undefined {
   const authHeader = request.headers.get('Authorization');
@@ -6,9 +7,7 @@ export function validateApiKey(request: NextRequest): NextResponse | undefined {
     return NextResponse.json({ error: { code: 401, message: 'API key missing or invalid.' } }, { status: 401 });
   }
   const providedKey = authHeader.slice('Bearer '.length).trim();
-  const validKeysEnv = process.env.VALID_API_KEYS || '';
-  const validKeys = validKeysEnv.split(',').map(k => k.trim()).filter(Boolean);
-  if (!validKeys.includes(providedKey)) {
+  if (!API_KEYS.includes(providedKey)) {
     return NextResponse.json({ error: { code: 401, message: 'API key missing or invalid.' } }, { status: 401 });
   }
   return undefined;

--- a/src/utils/__tests__/apiRoutesAuth.test.ts
+++ b/src/utils/__tests__/apiRoutesAuth.test.ts
@@ -8,6 +8,14 @@ const makeRequest = (url: string, headers: Record<string, string> = {}, body?: a
 } as any);
 
 describe('API routes authentication', () => {
+  beforeAll(() => {
+    process.env.VALID_API_KEYS = 'KEY1,KEY2';
+  });
+
+  afterAll(() => {
+    delete process.env.VALID_API_KEYS;
+  });
+
   it('returns 401 when Authorization header is missing', async () => {
     const res = await listDpp(makeRequest('http://test'));
     expect(res.status).toBe(401);
@@ -16,5 +24,17 @@ describe('API routes authentication', () => {
   it('returns 401 when API key is invalid', async () => {
     const res = await validateQr(makeRequest('http://test', { Authorization: 'Bearer BAD' }, { qrIdentifier: 'id' }));
     expect(res.status).toBe(401);
+  });
+
+  it('allows request when API key matches the first configured key', async () => {
+    const res = await listDpp(makeRequest('http://test', { Authorization: 'Bearer KEY1' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('allows request when API key matches another configured key', async () => {
+    const res = await validateQr(
+      makeRequest('http://test', { Authorization: 'Bearer KEY2' }, { qrIdentifier: 'DPP001' })
+    );
+    expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary
- centralize API key config into `src/config/auth.ts`
- use the list from `API_KEYS` in middleware
- document usage of `VALID_API_KEYS`
- test API key middleware with valid/invalid keys

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490e18c5f8832ab8cc77c3c3c978c2