### PR TITLE
Add import job status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,32 @@ curl -H 'Authorization: Bearer <API_KEY>' \
   https://api.example.com/api/v1/dpp/{productId}/credential
 ```
 
+### Checking Batch Import Job Status
+
+After submitting a batch import using `POST /api/v1/dpp/import` the response includes a `jobId` that can be polled for progress:
+
+```bash
+curl -H 'Authorization: Bearer <API_KEY>' \
+  https://api.example.com/api/v1/dpp/import/jobs/{jobId}
+```
+
+Example successful response:
+
+```json
+{
+  "jobId": "mock_import_job_123456",
+  "status": "PendingProcessing",
+  "message": "Job is queued."
+}
+```
+
+If the job ID is unknown a 404 error is returned:
+
+```json
+{
+  "error": { "code": 404, "message": "Job with ID UNKNOWN not found." }
+}
+```
 
 ## Getting Started
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -795,6 +795,51 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/dpp/import/jobs/{jobId}:
+    get:
+      operationId: getImportJobStatus
+      summary: Retrieve Batch Import Job Status
+      description: Returns the current status of a batch import job.
+      parameters:
+        - name: jobId
+          in: path
+          required: true
+          description: Identifier of the import job.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Current status information.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  status:
+                    type: string
+                    enum: ["PendingProcessing", "Completed", "Failed"]
+                  message:
+                    type: string
+        '401':
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Job not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/v1/dpp/graph/{productId}:
     get:
       operationId: getDppGraphData

--- a/src/app/api/v1/dpp/import/jobs/[jobId]/route.ts
+++ b/src/app/api/v1/dpp/import/jobs/[jobId]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { validateApiKey } from '@/middleware/apiKeyAuth';
+import { MOCK_IMPORT_JOBS } from '@/data';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { jobId: string } }
+) {
+  const auth = validateApiKey(request);
+  if (auth) return auth;
+
+  const job = MOCK_IMPORT_JOBS.get(params.jobId);
+
+  await new Promise(resolve => setTimeout(resolve, 100));
+
+  if (!job) {
+    return NextResponse.json(
+      { error: { code: 404, message: `Job with ID ${params.jobId} not found.` } },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json(job);
+}

--- a/src/app/api/v1/dpp/import/route.ts
+++ b/src/app/api/v1/dpp/import/route.ts
@@ -5,6 +5,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { validateApiKey } from '@/middleware/apiKeyAuth';
+import { MOCK_IMPORT_JOBS } from '@/data';
 
 interface ImportDppRequestBody {
   fileType?: string; // e.g., "csv", "json", "api"
@@ -48,6 +49,12 @@ export async function POST(request: NextRequest) {
   const mockProductsProcessed = Math.floor(Math.random() * 100) + 10; // Simulate some number of products
 
   const responseMessage = `Mock import request for fileType '${fileType}' received successfully.${sourceDescription ? ` Source: ${sourceDescription}.` : ''} In a real system, ${mockProductsProcessed} products would be queued for processing.`;
+
+  MOCK_IMPORT_JOBS.set(mockJobId, {
+    jobId: mockJobId,
+    status: 'PendingProcessing',
+    message: 'Job is queued.'
+  });
 
   return NextResponse.json({
     message: responseMessage,

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -2,3 +2,4 @@ export * from './mockDpps';
 export * from './simpleMockProducts';
 export * from './mockSuppliers';
 export * from './mockPublicPassports';
+export * from './mockImportJobs';

--- a/src/data/mockImportJobs.ts
+++ b/src/data/mockImportJobs.ts
@@ -1,0 +1,9 @@
+export type ImportJobStatus = 'PendingProcessing' | 'Completed' | 'Failed';
+
+export interface ImportJob {
+  jobId: string;
+  status: ImportJobStatus;
+  message?: string;
+}
+
+export const MOCK_IMPORT_JOBS = new Map<string, ImportJob>();

--- a/src/utils/__tests__/importJobRoute.test.ts
+++ b/src/utils/__tests__/importJobRoute.test.ts
@@ -1,0 +1,36 @@
+import { POST as importDpp } from '../../app/api/v1/dpp/import/route';
+import { GET as getJob } from '../../app/api/v1/dpp/import/jobs/[jobId]/route';
+
+function postRequest(body: any) {
+  return new Request('http://test', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { Authorization: 'Bearer TESTKEY' }
+  }) as any;
+}
+
+function getRequest() {
+  return new Request('http://test', { headers: { Authorization: 'Bearer TESTKEY' } }) as any;
+}
+
+describe('import job status route', () => {
+  beforeAll(() => {
+    process.env.VALID_API_KEYS = 'TESTKEY';
+  });
+
+  it('returns 404 for unknown job ID', async () => {
+    const res = await getJob(getRequest(), { params: { jobId: 'UNKNOWN' } });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns stored status for known job', async () => {
+    const postRes = await importDpp(postRequest({ fileType: 'csv', data: 'foo' }));
+    const postData = await postRes.json();
+    const jobId = postData.jobId;
+    const res = await getJob(getRequest(), { params: { jobId } });
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.status).toBe('PendingProcessing');
+    expect(data.jobId).toBe(jobId);
+  });
+});


### PR DESCRIPTION
## Summary
- define import job data structures
- store import jobs when POSTing to /import
- add GET /api/v1/dpp/import/jobs/{jobId} route
- document job status endpoint in README
- update API spec
- test job status route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490e16c2fc832abe0d1e00092a8bcb