### PR TITLE
Fix OverviewTab merge leftovers

### DIFF
--- a/src/components/products/detail/OverviewTab.tsx
+++ b/src/components/products/detail/OverviewTab.tsx
@@ -64,27 +64,6 @@ export default function OverviewTab({ product }: OverviewTabProps) {
           </CardHeader>
         </Card>
 
-<<<<<<< HEAD
-        <Card className="shadow-sm">
-          <CardHeader>
-            <CardTitle className="text-lg font-semibold flex items-center">
-              <Barcode className="mr-2 h-5 w-5 text-primary" />
-              Identifiers
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-sm space-y-1.5">
-            {product.modelNumber && (
-              <p><strong className="text-muted-foreground">Model:</strong> {product.modelNumber}</p>
-            )}
-            {product.gtin && (
-              <p><strong className="text-muted-foreground">GTIN:</strong> {product.gtin}</p>
-            )}
-            {!product.modelNumber && !product.gtin && (
-              <p className="text-muted-foreground">No identifiers provided.</p>
-            )}
-          </CardContent>
-        </Card>
-=======
         {(product.gtin || product.modelNumber || product.sku || product.nfcTagId || product.rfidTagId) && (
           <Card className="shadow-sm">
             <CardHeader>
@@ -112,7 +91,6 @@ export default function OverviewTab({ product }: OverviewTabProps) {
             </CardContent>
           </Card>
         )}
->>>>>>> 8361064e39b44a2e9346db4ec91f79cc406fcc2f
       </div>
 
       {/* Right Column: Description, Key Points, Specifications, Custom Attributes */}


### PR DESCRIPTION
## Summary
- remove conflict markers from `OverviewTab`
- keep SKU, GTIN, Model, NFC and RFID identifiers

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684912c2a7e4832a969e938a9b1e3ec4