### PR TITLE
Add country stats API

### DIFF
--- a/src/app/api/__tests__/countryStatsRoute.test.ts
+++ b/src/app/api/__tests__/countryStatsRoute.test.ts
@@ -1,0 +1,37 @@
+import { GET } from '../v1/dpp/country-stats/route';
+import { MOCK_DPPS } from '@/data';
+import { MOCK_DPPS as ORIGINAL_DPPS } from '@/data/mockDpps';
+import { NextRequest } from 'next/server';
+
+beforeEach(() => {
+  process.env.VALID_API_KEYS = 'SANDBOX_KEY_123';
+  MOCK_DPPS.length = 0;
+  ORIGINAL_DPPS.forEach(d => MOCK_DPPS.push(JSON.parse(JSON.stringify(d))));
+});
+
+describe('/api/v1/dpp/country-stats route', () => {
+  it('aggregates DPP counts by originCountry', async () => {
+    const req = new NextRequest(new Request('http://test', {
+      headers: { Authorization: 'Bearer SANDBOX_KEY_123' }
+    }));
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    const expected: Record<string, number> = {};
+    ORIGINAL_DPPS.forEach(d => {
+      const c = d.traceability?.originCountry || 'unknown';
+      expected[c] = (expected[c] || 0) + 1;
+    });
+    expect(data).toEqual(
+      expect.arrayContaining(
+        Object.entries(expected).map(([countryCode, count]) => ({ countryCode, count }))
+      )
+    );
+  });
+
+  it('returns 401 when API key missing', async () => {
+    const req = new NextRequest(new Request('http://test'));
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/v1/dpp/country-stats/route.ts
+++ b/src/app/api/v1/dpp/country-stats/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { MOCK_DPPS } from '@/data';
+import { validateApiKey } from '@/middleware/apiKeyAuth';
+
+export async function GET(request: NextRequest) {
+  const auth = validateApiKey(request);
+  if (auth) return auth;
+
+  const counts: Record<string, number> = {};
+  for (const dpp of MOCK_DPPS) {
+    const country = dpp.traceability?.originCountry || 'unknown';
+    counts[country] = (counts[country] || 0) + 1;
+  }
+
+  const result = Object.entries(counts).map(([countryCode, count]) => ({ countryCode, count }));
+  return NextResponse.json(result);
+}

--- a/src/data/mockDpps.ts
+++ b/src/data/mockDpps.ts
@@ -54,6 +54,7 @@ export const MOCK_DPPS: DigitalProductPassport[] = [
       { name: "Warranty Card", url: "#warranty.pdf", type: "Warranty", addedTimestamp: "2024-01-15T00:00:00Z" },
     ],
     traceability: {
+    originCountry: "DE",
       supplyChainSteps: [
         {
           stepName: 'Manufactured',
@@ -97,6 +98,7 @@ export const MOCK_DPPS: DigitalProductPassport[] = [
     ],
     documents: [],
     traceability: {
+    originCountry: "IN",
       supplyChainSteps: [
         {
           stepName: 'Manufactured',
@@ -129,6 +131,7 @@ export const MOCK_DPPS: DigitalProductPassport[] = [
      blockchainIdentifiers: { platform: "OtherChain", anchorTransactionHash: "0x789polymerAnchorHash000333"},
     documents: [],
     traceability: {
+      originCountry: "CN",
       supplyChainSteps: [
         {
           stepName: 'Manufactured',
@@ -158,6 +161,7 @@ export const MOCK_DPPS: DigitalProductPassport[] = [
     productDetails: { description: "A modular sofa."},
     documents: [],
     traceability: {
+      originCountry: "SE",
       supplyChainSteps: [
         {
           stepName: 'Manufactured',
@@ -205,6 +209,7 @@ export const MOCK_DPPS: DigitalProductPassport[] = [
     ],
     documents: [],
     traceability: {
+      originCountry: "US",
       supplyChainSteps: [
         {
           stepName: 'Manufactured',


### PR DESCRIPTION
## Summary
- add `/api/v1/dpp/country-stats` endpoint to aggregate DPPs by originCountry
- extend mock DPP data with `originCountry`
- test new endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684912fa7898832a83982efd12fb14f7