### PR TITLE
Add global tracker link and supply chain highlighting

### DIFF
--- a/src/app/(app)/dpp-global-tracker-v2/page.tsx
+++ b/src/app/(app)/dpp-global-tracker-v2/page.tsx
@@ -7,6 +7,7 @@ import type { GlobeMethods } from 'react-globe.gl';
 import type { Feature as GeoJsonFeature, FeatureCollection, Geometry, GeoJsonProperties } from 'geojson';
 import { MeshPhongMaterial } from 'three';
 import { Loader2, Info } from 'lucide-react';
+import { useSearchParams } from 'next/navigation';
 
 // Dynamically import Globe for client-side rendering
 const Globe = dynamic(() => import('react-globe.gl'), { 
@@ -44,6 +45,10 @@ export default function GlobeV2Page() {
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const [globeReady, setGlobeReady] = useState(false);
   const [dataLoaded, setDataLoaded] = useState(false);
+  const [highlightedCountries, setHighlightedCountries] = useState<string[]>([]);
+
+  const searchParams = useSearchParams();
+  const productId = searchParams.get('productId');
 
   // Approximate header height (adjust if your header height is different or dynamic)
   const HEADER_HEIGHT = 64; // Example: 4rem = 64px
@@ -82,6 +87,32 @@ export default function GlobeV2Page() {
       });
   }, []);
 
+  // Fetch supply chain graph data when a productId is provided
+  useEffect(() => {
+    if (!productId) return;
+
+    fetch(`/api/v1/dpp/graph/${productId}`)
+      .then(res => res.json())
+      .then((graph) => {
+        const countries = new Set<string>();
+        if (graph?.nodes) {
+          graph.nodes.forEach((node: any) => {
+            if (node.type === 'supplier' || node.type === 'manufacturer') {
+              const loc: string | undefined = node.data?.location;
+              if (loc) {
+                const country = loc.split(',').pop()?.trim();
+                if (country) countries.add(country);
+              }
+            }
+          });
+        }
+        setHighlightedCountries(Array.from(countries));
+      })
+      .catch((err) => {
+        console.error('Error fetching product graph:', err);
+      });
+  }, [productId]);
+
   // Function to determine if a country is in the EU based on its ISO A3 code
   const isEU = useCallback((isoA3: string | undefined) => {
     return !!isoA3 && EU_COUNTRY_CODES.has(isoA3.toUpperCase());
@@ -114,8 +145,12 @@ export default function GlobeV2Page() {
   const getPolygonCapColor = useCallback((feat: object) => {
     const properties = (feat as CountryFeature).properties;
     const iso = properties?.ADM0_A3 || properties?.ISO_A3;
+    const name = properties?.ADMIN;
+    if (highlightedCountries.includes(name)) {
+      return '#f97316'; // orange highlight for supply chain countries
+    }
     return isEU(iso) ? '#002D62' : '#CCCCCC'; // Dark blue for EU, light grey for others
-  }, [isEU]);
+  }, [isEU, highlightedCountries]);
 
   // Show loader if dimensions are not set or data is not loaded yet
   if (dimensions.width === 0 || dimensions.height === 0 || !dataLoaded) {

--- a/src/components/products/detail/ProductHeader.tsx
+++ b/src/components/products/detail/ProductHeader.tsx
@@ -4,6 +4,8 @@
 import type { SimpleProductDetail } from "@/types/dpp";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { Package, Tag, Building, CheckCircle, AlertTriangle, Info, ShieldCheck, Barcode } from "lucide-react"; // Added Barcode
 import { getStatusIcon as getComplianceStatusIcon, getStatusBadgeVariant as getComplianceBadgeVariant, getStatusBadgeClasses as getComplianceBadgeClasses } from "@/utils/dppDisplayUtils";
@@ -106,6 +108,13 @@ export default function ProductHeader({ product }: ProductHeaderProps) {
             )}
         </div>
         <QrCodeGenerator productId={product.id} />
+        <div className="mt-4 flex justify-center">
+          <Button asChild variant="outline" size="sm">
+            <Link href={`/dpp-global-tracker-v2?productId=${product.id}`}>
+              View on Global Tracker
+            </Link>
+          </Button>
+        </div>
       </CardHeader>
     </Card>
   );


### PR DESCRIPTION
## Summary
- link products to the Global Tracker page
- highlight supply chain countries on the globe when a `productId` is provided

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68491c6458e8832a89f29279479f197c