### PR TITLE
Add country-based pathway selection

### DIFF
--- a/src/app/(app)/compliance/pathways/battery-regulation/page.tsx
+++ b/src/app/(app)/compliance/pathways/battery-regulation/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import React, { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { CheckCircle, Recycle, Handshake, PackageCheck, SearchCheck } from 'lucide-react';
 import BatteryRegulationStep, { WizardStep } from '@/components/compliance/BatteryRegulationStep';
 import { useToast } from '@/hooks/use-toast';
+import { Badge } from '@/components/ui/badge';
 
 const euBatteryRegulationSteps: WizardStep[] = [
   { id: 'step1', title: 'General Information', description: 'Provide basic details about the battery product.' },
@@ -22,6 +23,9 @@ const euBatteryRegulationSteps: WizardStep[] = [
 
 export default function BatteryRegulationPathwayPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const countryParam = searchParams.get('country');
+  const country = countryParam ? decodeURIComponent(countryParam) : null;
   const [activeStep, setActiveStep] = useState<string>(euBatteryRegulationSteps[0].id);
   const [formData, setFormData] = useState<Record<string, any>>({
     step1_batteryModel: '',
@@ -108,6 +112,9 @@ export default function BatteryRegulationPathwayPage() {
         <CardHeader>
           <CardTitle className="text-2xl font-headline text-primary">EU Battery Regulation Compliance Pathway</CardTitle>
           <CardDescription>Follow these steps to prepare your Digital Battery Passport information.</CardDescription>
+          {country && (
+            <p className="mt-2 text-sm"><Badge variant="outline">Guidance for {country}</Badge></p>
+          )}
         </CardHeader>
         <CardContent>
           <div className="mb-6 p-4 border rounded-lg bg-muted/50">

--- a/src/app/(app)/compliance/pathways/csrd/page.tsx
+++ b/src/app/(app)/compliance/pathways/csrd/page.tsx
@@ -5,9 +5,14 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { useSearchParams } from 'next/navigation';
+import { Badge } from '@/components/ui/badge';
 import { ArrowLeft, BookOpen, Info, Layers, BarChart3, Cpu, Link as LinkIcon } from "lucide-react";
 
 export default function CsrdAlignmentGuidePage() {
+  const searchParams = useSearchParams();
+  const countryParam = searchParams.get('country');
+  const country = countryParam ? decodeURIComponent(countryParam) : null;
   const csrdSections = [
     {
       icon: Layers,
@@ -59,6 +64,9 @@ export default function CsrdAlignmentGuidePage() {
           <BookOpen className="mr-3 h-7 w-7 text-primary" />
           CSRD Alignment Guide (Conceptual)
         </h1>
+        {country && (
+          <Badge variant="outline" className="ml-3">Guidance for {country}</Badge>
+        )}
         <Button variant="outline" asChild>
           <Link href="/compliance/pathways">
             <ArrowLeft className="mr-2 h-4 w-4" />

--- a/src/app/(app)/compliance/pathways/espr/page.tsx
+++ b/src/app/(app)/compliance/pathways/espr/page.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import React, { useState } from 'react';
-import { useRouter } from 'next/navigation'; // Import useRouter
+import { useRouter, useSearchParams } from 'next/navigation'; // Import useRouter and useSearchParams
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -12,6 +12,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Checkbox } from '@/components/ui/checkbox';
 import { Lightbulb, CheckCircle, Loader2, Info, Recycle, Package, Wrench, FileText as FileTextIcon, SearchCheck, ExternalLink } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { Badge } from '@/components/ui/badge';
 
 interface WizardStep {
   id: string;
@@ -32,6 +33,9 @@ const esprPathwaySteps: WizardStep[] = [
 
 export default function EsprPathwayPage() {
   const router = useRouter(); // Initialize router
+  const searchParams = useSearchParams();
+  const countryParam = searchParams.get('country');
+  const country = countryParam ? decodeURIComponent(countryParam) : null;
   const [activeStep, setActiveStep] = useState<string>(esprPathwaySteps[0].id);
   const [formData, setFormData] = useState<Record<string, any>>({
     step1_productCategory: "",
@@ -290,6 +294,9 @@ export default function EsprPathwayPage() {
         <CardHeader>
           <CardTitle className="text-2xl font-headline text-primary">EU ESPR Compliance Pathway</CardTitle>
           <CardDescription>Navigate the Ecodesign for Sustainable Products Regulation requirements step-by-step.</CardDescription>
+          {country && (
+            <p className="mt-2 text-sm"><Badge variant="outline">Guidance for {country}</Badge></p>
+          )}
         </CardHeader>
         <CardContent>
             <div className="mb-6 p-4 border rounded-lg bg-muted/50">

--- a/src/app/(app)/compliance/pathways/page.tsx
+++ b/src/app/(app)/compliance/pathways/page.tsx
@@ -2,8 +2,10 @@
 "use client";
 
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { ArrowRight, BookOpen, BatteryCharging, Recycle, ShieldAlert, Construction, Database } from 'lucide-react'; // Added Database icon
 
 interface Pathway {
@@ -50,7 +52,21 @@ const pathways: Pathway[] = [
   },
 ];
 
+const EU_COUNTRIES = [
+  'austria','belgium','bulgaria','croatia','cyprus','czechia','czech republic','denmark','estonia',
+  'finland','france','germany','greece','hungary','ireland','italy','latvia','lithuania',
+  'luxembourg','malta','netherlands','poland','portugal','romania','slovakia','slovenia',
+  'spain','sweden','eu'
+];
+
+const isEUCountry = (country: string | null) =>
+  country ? EU_COUNTRIES.includes(country.toLowerCase()) : false;
+
 export default function CompliancePathwaysPage() {
+  const searchParams = useSearchParams();
+  const countryParam = searchParams.get('country');
+  const country = countryParam ? decodeURIComponent(countryParam) : null;
+  const highlightEU = isEUCountry(country);
   return (
     <div className="space-y-8">
       <div className="text-center">
@@ -59,6 +75,11 @@ export default function CompliancePathwaysPage() {
         <p className="mt-3 text-lg text-muted-foreground max-w-2xl mx-auto">
           Step-by-step guidance, tools, and resources to help you meet specific EU regulations and standards for your Digital Product Passports.
         </p>
+        {highlightEU && country && (
+          <p className="mt-2">
+            <Badge variant="outline">Guidance for {country}</Badge>
+          </p>
+        )}
       </div>
 
       <Card className="shadow-xl">
@@ -78,8 +99,13 @@ export default function CompliancePathwaysPage() {
       <div>
         <h2 className="text-2xl font-semibold mb-6 text-center font-headline">Available & Upcoming Pathways</h2>
         <div className="grid md:grid-cols-2 gap-6">
-          {pathways.map((pathway) => (
-            <Card key={pathway.id} className={`shadow-lg flex flex-col ${pathway.status === 'coming_soon' ? 'opacity-70' : ''}`}>
+          {pathways.map((pathway) => {
+            const linkHref = country ? `${pathway.href}?country=${encodeURIComponent(country)}` : pathway.href;
+            return (
+            <Card
+              key={pathway.id}
+              className={`shadow-lg flex flex-col ${pathway.status === 'coming_soon' ? 'opacity-70' : ''} ${highlightEU ? 'ring-2 ring-primary' : ''}`}
+            >
               <CardHeader className="flex-shrink-0">
                 <div className="flex items-start justify-between">
                   <pathway.icon className="h-10 w-10 text-primary mb-3 flex-shrink-0" />
@@ -96,7 +122,7 @@ export default function CompliancePathwaysPage() {
               </CardContent>
               <div className="p-6 pt-0 mt-auto">
                 {pathway.status === 'active' ? (
-                  <Link href={pathway.href} passHref>
+                  <Link href={linkHref} passHref>
                     <Button className="w-full bg-primary text-primary-foreground hover:bg-primary/90">
                       Start Pathway <ArrowRight className="ml-2 h-4 w-4" />
                     </Button>
@@ -108,7 +134,8 @@ export default function CompliancePathwaysPage() {
                 )}
               </div>
             </Card>
-          ))}
+            );
+          })}
         </div>
       </div>
 

--- a/src/app/(app)/compliance/pathways/scip/page.tsx
+++ b/src/app/(app)/compliance/pathways/scip/page.tsx
@@ -6,9 +6,14 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { useSearchParams } from 'next/navigation';
+import { Badge } from '@/components/ui/badge';
 import { ArrowLeft, ShieldAlert, Database, Info, Layers, ListChecks, ExternalLink, UploadCloud } from "lucide-react";
 
 export default function ScipNotificationHelperPage() {
+  const searchParams = useSearchParams();
+  const countryParam = searchParams.get('country');
+  const country = countryParam ? decodeURIComponent(countryParam) : null;
   const scipSections = [
     {
       icon: Layers,
@@ -52,6 +57,9 @@ export default function ScipNotificationHelperPage() {
           <ShieldAlert className="mr-3 h-7 w-7 text-primary" />
           SCIP Database Notification Helper (Conceptual)
         </h1>
+        {country && (
+          <Badge variant="outline" className="ml-3">Guidance for {country}</Badge>
+        )}
         <Button variant="outline" asChild>
           <Link href="/compliance/pathways">
             <ArrowLeft className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- support optional `country` query in pathways page
- forward query string to pathway subpages
- display jurisdiction badge on pathway subpages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68491de22838832a8000ba5cf7434e8f