### PR TITLE
Add EU highlighting via ISO codes

### DIFF
--- a/src/app/(app)/compliance/pathways/csrd/page.tsx
+++ b/src/app/(app)/compliance/pathways/csrd/page.tsx
@@ -68,7 +68,7 @@ export default function CsrdAlignmentGuidePage() {
           <Badge variant="outline" className="ml-3">Guidance for {country}</Badge>
         )}
         <Button variant="outline" asChild>
-          <Link href="/compliance/pathways">
+          <Link href={country ? `/compliance/pathways?country=${encodeURIComponent(country)}` : '/compliance/pathways'}>
             <ArrowLeft className="mr-2 h-4 w-4" />
             Back to Compliance Pathways
           </Link>

--- a/src/app/(app)/compliance/pathways/page.tsx
+++ b/src/app/(app)/compliance/pathways/page.tsx
@@ -3,6 +3,7 @@
 
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
+import { isEuCountry } from '@/lib/euCountryCodes';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -15,6 +16,7 @@ interface Pathway {
   icon: React.ElementType;
   href: string;
   status: 'active' | 'coming_soon';
+  euSpecific?: boolean;
 }
 
 const pathways: Pathway[] = [
@@ -25,6 +27,7 @@ const pathways: Pathway[] = [
     icon: BatteryCharging,
     href: '/compliance/pathways/battery-regulation',
     status: 'active',
+    euSpecific: true,
   },
   {
     id: 'espr',
@@ -33,6 +36,7 @@ const pathways: Pathway[] = [
     icon: Recycle,
     href: '/compliance/pathways/espr',
     status: 'active',
+    euSpecific: true,
   },
   {
     id: 'csrd',
@@ -41,6 +45,7 @@ const pathways: Pathway[] = [
     icon: BookOpen,
     href: '/compliance/pathways/csrd',
     status: 'active',
+    euSpecific: true,
   },
   {
     id: 'scip',
@@ -49,24 +54,15 @@ const pathways: Pathway[] = [
     icon: Database, // Updated icon to Database
     href: '/compliance/pathways/scip', // Updated href
     status: 'active', // Updated status
+    euSpecific: true,
   },
 ];
-
-const EU_COUNTRIES = [
-  'austria','belgium','bulgaria','croatia','cyprus','czechia','czech republic','denmark','estonia',
-  'finland','france','germany','greece','hungary','ireland','italy','latvia','lithuania',
-  'luxembourg','malta','netherlands','poland','portugal','romania','slovakia','slovenia',
-  'spain','sweden','eu'
-];
-
-const isEUCountry = (country: string | null) =>
-  country ? EU_COUNTRIES.includes(country.toLowerCase()) : false;
 
 export default function CompliancePathwaysPage() {
   const searchParams = useSearchParams();
   const countryParam = searchParams.get('country');
   const country = countryParam ? decodeURIComponent(countryParam) : null;
-  const highlightEU = isEUCountry(country);
+  const highlightEU = isEuCountry(country);
   return (
     <div className="space-y-8">
       <div className="text-center">
@@ -104,7 +100,7 @@ export default function CompliancePathwaysPage() {
             return (
             <Card
               key={pathway.id}
-              className={`shadow-lg flex flex-col ${pathway.status === 'coming_soon' ? 'opacity-70' : ''} ${highlightEU ? 'ring-2 ring-primary' : ''}`}
+              className={`shadow-lg flex flex-col ${pathway.status === 'coming_soon' ? 'opacity-70' : ''} ${highlightEU && pathway.euSpecific ? 'ring-2 ring-primary' : ''}`}
             >
               <CardHeader className="flex-shrink-0">
                 <div className="flex items-start justify-between">

--- a/src/app/(app)/compliance/pathways/scip/page.tsx
+++ b/src/app/(app)/compliance/pathways/scip/page.tsx
@@ -61,7 +61,7 @@ export default function ScipNotificationHelperPage() {
           <Badge variant="outline" className="ml-3">Guidance for {country}</Badge>
         )}
         <Button variant="outline" asChild>
-          <Link href="/compliance/pathways">
+          <Link href={country ? `/compliance/pathways?country=${encodeURIComponent(country)}` : '/compliance/pathways'}>
             <ArrowLeft className="mr-2 h-4 w-4" />
             Back to Compliance Pathways
           </Link>

--- a/src/lib/euCountryCodes.ts
+++ b/src/lib/euCountryCodes.ts
@@ -1,0 +1,8 @@
+export const EU_COUNTRY_CODES: Set<string> = new Set([
+  'AUT','BEL','BGR','HRV','CYP','CZE','DNK','EST','FIN','FRA','DEU','GRC','HUN','IRL','ITA','LVA','LTU','LUX','MLT','NLD','POL','PRT','ROU','SVK','SVN','ESP','SWE'
+]);
+
+export function isEuCountry(code: string | null | undefined): boolean {
+  if (!code) return false;
+  return EU_COUNTRY_CODES.has(code.toUpperCase());
+}


### PR DESCRIPTION
## Summary
- expose EU ISO A3 codes and helper
- highlight EU pathways when a valid EU country code is passed in query params
- pass the `country` query parameter in back links of pathway pages

## Testing
- `npm run typecheck` *(fails: Cannot find modules)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68491fdeeac0832a92f6d9e9b752f0ae