### PR TITLE
Add anchor and transfer-ownership API tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ npm test
 ```
 
 The suite now includes API route tests located in `src/app/api/__tests__`. These
-cover common success and failure cases for the DPP and QR validation endpoints.
+cover common success and failure cases for several endpoints including DPP
+creation, QR validation, anchoring, and ownership transfer.
 
 
 Use `npm run test:watch` during development to re-run tests on file changes.

--- a/src/app/api/__tests__/anchorRoute.test.ts
+++ b/src/app/api/__tests__/anchorRoute.test.ts
@@ -1,0 +1,58 @@
+import { POST } from '../v1/dpp/anchor/[productId]/route';
+import { MOCK_DPPS } from '@/data';
+import { MOCK_DPPS as ORIGINAL_DPPS } from '@/data/mockDpps';
+import { NextRequest } from 'next/server';
+
+beforeEach(() => {
+  process.env.VALID_API_KEYS = 'SANDBOX_KEY_123';
+  MOCK_DPPS.length = 0;
+  ORIGINAL_DPPS.forEach(d => MOCK_DPPS.push(JSON.parse(JSON.stringify(d))));
+});
+
+describe('POST /api/v1/dpp/anchor/[productId]', () => {
+  it('anchors an existing product when payload is valid', async () => {
+    const req = new NextRequest(new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ platform: 'Ethereum' }),
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer SANDBOX_KEY_123'
+      }
+    }));
+
+    const res = await POST(req, { params: { productId: 'DPP001' } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.blockchainIdentifiers?.anchorTransactionHash).toBeDefined();
+    expect(MOCK_DPPS.find(d => d.id === 'DPP001')?.blockchainIdentifiers?.anchorTransactionHash).toBeDefined();
+  });
+
+  it('returns 404 for unknown product', async () => {
+    const req = new NextRequest(new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ platform: 'Ethereum' }),
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer SANDBOX_KEY_123' }
+    }));
+    const res = await POST(req, { params: { productId: 'BAD_ID' } });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when platform is missing', async () => {
+    const req = new NextRequest(new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({}),
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer SANDBOX_KEY_123' }
+    }));
+    const res = await POST(req, { params: { productId: 'DPP001' } });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when API key is missing', async () => {
+    const req = new NextRequest(new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ platform: 'Ethereum' })
+    }));
+    const res = await POST(req, { params: { productId: 'DPP001' } });
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/__tests__/transferOwnership.test.ts
+++ b/src/app/api/__tests__/transferOwnership.test.ts
@@ -1,6 +1,13 @@
 import { POST } from '../v1/dpp/transfer-ownership/[productId]/route';
 import { MOCK_DPPS } from '@/data';
+import { MOCK_DPPS as ORIGINAL_DPPS } from '@/data/mockDpps';
 import { NextRequest } from 'next/server';
+
+beforeEach(() => {
+  process.env.VALID_API_KEYS = 'SANDBOX_KEY_123';
+  MOCK_DPPS.length = 0;
+  ORIGINAL_DPPS.forEach(d => MOCK_DPPS.push(JSON.parse(JSON.stringify(d))));
+});
 
 describe('POST /api/v1/dpp/transfer-ownership/[productId]', () => {
   it('updates manufacturer and traceability for existing product', async () => {
@@ -38,5 +45,19 @@ describe('POST /api/v1/dpp/transfer-ownership/[productId]', () => {
     }));
     const response = await POST(request, { params: { productId: 'BAD_ID' } });
     expect(response.status).toBe(404);
+  });
+
+  it('returns 401 when API key is missing', async () => {
+    const payload = {
+      newOwner: { name: 'No Auth Inc', did: 'did:example:noauth' },
+      transferTimestamp: '2024-08-01T12:00:00Z',
+    };
+    const request = new NextRequest(new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    const res = await POST(request, { params: { productId: 'DPP001' } });
+    expect(res.status).toBe(401);
   });
 });


### PR DESCRIPTION
## Summary
- test anchoring route success/failure/unauth cases
- extend transfer ownership tests for env reset and auth failure case
- note new API tests in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684928be96dc832aa453607a875926bd