### PR TITLE
Add ERC-721 UUPS contract with Hardhat setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,9 @@ GOOGLE_APPLICATION_CREDENTIALS=
 # These values populate the `API_KEYS` array in `src/config/auth.ts`.
 VALID_API_KEYS=SANDBOX_KEY_123,PROD_KEY_456
 
+
+# Optional Hardhat deployment settings
+ALCHEMY_API_KEY=
+PRIVATE_KEY=
+# Proxy address for upgrade script
+PROXY_ADDRESS=

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Welcome to the Norruva Digital Product Passport (DPP) concept application! This 
 - [Product Detail Page](#product-detail-page)
 - [Blockchain Anchoring & Ownership](#blockchain-anchoring--ownership)
 - [Advanced Blockchain Architecture](#advanced-blockchain-architecture)
+- [Smart Contract Development](#smart-contract-development)
 - [Getting Started](#getting-started)
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
@@ -298,6 +299,33 @@ Without this permission Google Cloud cannot generate the access token required t
 ## Advanced Blockchain Architecture
 
 Detailed smart contract design and DAO governance specifications are documented in [docs/blockchain-architecture.md](docs/blockchain-architecture.md).
+
+## Smart Contract Development
+
+Solidity contracts live in the `contracts/` directory. The project includes **Hardhat** and **Foundry** configurations for local development and upgrades.
+
+### Common Commands
+
+```bash
+# Compile the contracts
+npm run compile:contracts
+
+# Execute the Hardhat test suite
+npm run test:contracts
+
+# Deploy the proxy to a network (requires ALCHEMY_API_KEY and PRIVATE_KEY)
+npm run deploy:contracts
+
+# Upgrade an existing proxy (set PROXY_ADDRESS in `.env`)
+npm run upgrade:contracts
+```
+
+If Foundry is installed you can also run:
+
+```bash
+forge build
+forge test
+```
 
 ## Firebase Studio Context
 

--- a/contracts/DPPToken.sol
+++ b/contracts/DPPToken.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+contract DPPToken is Initializable, ERC721Upgradeable, AccessControlUpgradeable, UUPSUpgradeable {
+    bytes32 public constant TRANSFER_ROLE = keccak256("TRANSFER_ROLE");
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+
+    function initialize(address admin) public initializer {
+        __ERC721_init("Digital Product Passport Token", "DPP");
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(TRANSFER_ROLE, admin);
+        _grantRole(UPGRADER_ROLE, admin);
+        _grantRole(MINTER_ROLE, admin);
+    }
+
+    function mint(address to, uint256 tokenId) external onlyRole(MINTER_ROLE) {
+        _safeMint(to, tokenId);
+    }
+
+    function approve(address, uint256) public pure override {
+        revert("Soulbound");
+    }
+
+    function setApprovalForAll(address, bool) public pure override {
+        revert("Soulbound");
+    }
+
+    function _beforeTokenTransfer(address from, address to, uint256 tokenId, uint256 batchSize)
+        internal
+        override
+    {
+        if (from != address(0) && to != address(0)) {
+            require(hasRole(TRANSFER_ROLE, _msgSender()), "Transfer restricted");
+        }
+        super._beforeTokenTransfer(from, to, tokenId, batchSize);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(ERC721Upgradeable, AccessControlUpgradeable)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+}
+

--- a/contracts/DPPTokenV2.sol
+++ b/contracts/DPPTokenV2.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./DPPToken.sol";
+
+contract DPPTokenV2 is DPPToken {
+    function version() external pure returns (uint256) {
+        return 2;
+    }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,4 @@
+[profile.default]
+src = 'contracts'
+out = 'out'
+libs = ['lib']

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,0 +1,29 @@
+import { HardhatUserConfig } from "hardhat/config";
+import "@nomicfoundation/hardhat-toolbox";
+import "@openzeppelin/hardhat-upgrades";
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+const config: HardhatUserConfig = {
+  solidity: "0.8.20",
+  paths: {
+    sources: "./contracts",
+    tests: "./test",
+    cache: "./cache",
+    artifacts: "./artifacts",
+  },
+  networks: {
+    hardhat: {},
+    ...(process.env.ALCHEMY_API_KEY && process.env.PRIVATE_KEY
+      ? {
+          sepolia: {
+            url: `https://eth-sepolia.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
+            accounts: [process.env.PRIVATE_KEY],
+          },
+        }
+      : {}),
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "compile:contracts": "hardhat compile",
+    "test:contracts": "hardhat test",
+    "deploy:contracts": "hardhat run scripts/deploy.ts --network sepolia",
+    "upgrade:contracts": "hardhat run scripts/upgrade.ts --network sepolia"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.12.0",
@@ -62,7 +66,8 @@
     "topojson-client": "^3.1.0",
     "zod": "^3.24.2",
     "react-qr-code": "^2.0.7",
-    "qrcode": "^1.5.3"
+    "qrcode": "^1.5.3",
+    "@openzeppelin/contracts-upgradeable": "^5.0.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.7",
@@ -76,6 +81,10 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "ts-jest": "^29.1.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "hardhat": "^2.22.0",
+    "@nomicfoundation/hardhat-toolbox": "^3.0.0",
+    "@openzeppelin/hardhat-upgrades": "^1.36.0",
+    "ts-node": "^10.9.1"
   }
 }

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1,0 +1,17 @@
+import { ethers, upgrades } from "hardhat";
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  const DPPToken = await ethers.getContractFactory("DPPToken");
+  const proxy = await upgrades.deployProxy(DPPToken, [deployer.address], {
+    kind: "uups",
+  });
+
+  await proxy.waitForDeployment();
+  console.log("DPPToken deployed to:", await proxy.getAddress());
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/upgrade.ts
+++ b/scripts/upgrade.ts
@@ -1,0 +1,19 @@
+import { ethers, upgrades } from "hardhat";
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+async function main() {
+  const proxyAddress = process.env.PROXY_ADDRESS;
+  if (!proxyAddress) throw new Error("PROXY_ADDRESS env var required");
+
+  const DPPTokenV2 = await ethers.getContractFactory("DPPTokenV2");
+  const upgraded = await upgrades.upgradeProxy(proxyAddress, DPPTokenV2);
+  await upgraded.waitForDeployment();
+  console.log("DPPToken upgraded:", await upgraded.getAddress());
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/test/DPPToken.ts
+++ b/test/DPPToken.ts
@@ -1,0 +1,33 @@
+import { expect } from "chai";
+import { ethers, upgrades } from "hardhat";
+
+describe("DPPToken", function () {
+  it("mints and restricts transfers", async function () {
+    const [admin, user1, user2] = await ethers.getSigners();
+    const DPPToken = await ethers.getContractFactory("DPPToken");
+    const token = await upgrades.deployProxy(DPPToken, [admin.address], { kind: "uups" });
+
+    await token.mint(user1.address, 1);
+    expect(await token.ownerOf(1)).to.equal(user1.address);
+
+    await expect(token.connect(user1).transferFrom(user1.address, user2.address, 1)).to.be.revertedWith(
+      "Transfer restricted"
+    );
+
+    await token.grantRole(await token.TRANSFER_ROLE(), user1.address);
+    await token.connect(user1).transferFrom(user1.address, user2.address, 1);
+    expect(await token.ownerOf(1)).to.equal(user2.address);
+
+    await expect(token.approve(user1.address, 1)).to.be.revertedWith("Soulbound");
+  });
+
+  it("upgrades to v2", async function () {
+    const [admin] = await ethers.getSigners();
+    const DPPToken = await ethers.getContractFactory("DPPToken");
+    const token = await upgrades.deployProxy(DPPToken, [admin.address], { kind: "uups" });
+
+    const DPPTokenV2 = await ethers.getContractFactory("DPPTokenV2");
+    const upgraded = await upgrades.upgradeProxy(await token.getAddress(), DPPTokenV2);
+    expect(await upgraded.version()).to.equal(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add `DPPToken` ERC-721 UUPS contract and upgradeable `DPPTokenV2`
- configure Hardhat and Foundry
- provide deploy/upgrade scripts and unit tests
- extend `.env.example` with blockchain vars
- document contract workflow in README

## Testing
- `npx hardhat test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684928bde890832a9c57991c2f840d98