### PR TITLE
Add DPP token API endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -983,6 +983,132 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/token/mint/{productId}:
+    post:
+      operationId: mintDppToken
+      summary: Mint DPP Token
+      description: Mints a blockchain token representing the specified Digital Product Passport.
+      parameters:
+        - name: productId
+          in: path
+          required: true
+          description: The unique identifier of the product.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MintTokenRequest'
+      responses:
+        '201':
+          description: Token minted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MintTokenResponse'
+        '401':
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Product not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/token/metadata/{tokenId}:
+    patch:
+      operationId: updateTokenMetadata
+      summary: Update Token Metadata
+      description: Updates on-chain metadata URI for a minted DPP token.
+      parameters:
+        - name: tokenId
+          in: path
+          required: true
+          description: The blockchain token ID.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateTokenMetadataRequest'
+      responses:
+        '200':
+          description: Metadata updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateTokenMetadataResponse'
+        '401':
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Token not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/token/status/{tokenId}:
+    get:
+      operationId: getTokenStatus
+      summary: Retrieve Token On-Chain Status
+      description: Retrieves on-chain information for a DPP token.
+      parameters:
+        - name: tokenId
+          in: path
+          required: true
+          description: The blockchain token ID.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: On-chain status information.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenStatusResponse'
+        '401':
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Token not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/v1/qr/generate/{productId}:
     get:
       operationId: generateQrCode
@@ -1953,6 +2079,73 @@ paths:
           nullable: true
           items:
             $ref: '#/components/schemas/DocumentReference'
+    MintTokenRequest:
+      type: object
+      required:
+        - contractAddress
+        - recipientAddress
+      properties:
+        contractAddress:
+          type: string
+          description: Smart contract address used for minting.
+        recipientAddress:
+          type: string
+          description: Blockchain address receiving the token.
+        metadataUri:
+          type: string
+          nullable: true
+          description: URI for the off-chain metadata.
+    MintTokenResponse:
+      type: object
+      properties:
+        tokenId:
+          type: string
+        contractAddress:
+          type: string
+        transactionHash:
+          type: string
+    UpdateTokenMetadataRequest:
+      type: object
+      required:
+        - metadataUri
+      properties:
+        metadataUri:
+          type: string
+          description: New metadata URI for the token.
+        contractAddress:
+          type: string
+          nullable: true
+          description: Contract address if different from default.
+    UpdateTokenMetadataResponse:
+      type: object
+      properties:
+        tokenId:
+          type: string
+        contractAddress:
+          type: string
+        transactionHash:
+          type: string
+    TokenStatusResponse:
+      type: object
+      properties:
+        tokenId:
+          type: string
+        contractAddress:
+          type: string
+        ownerAddress:
+          type: string
+        mintedAt:
+          type: string
+          format: date-time
+        metadataUri:
+          type: string
+          nullable: true
+        lastTransactionHash:
+          type: string
+          nullable: true
+        status:
+          type: string
+          description: Current on-chain status of the token.
 security:
   - ApiKeyAuth: []
 components:

--- a/src/app/(app)/developer/docs/api-reference/page.tsx
+++ b/src/app/(app)/developer/docs/api-reference/page.tsx
@@ -6,6 +6,7 @@ import ApiReferenceIntro from '@/components/developer/docs/ApiReferenceIntro';
 import ApiReferenceDppEndpoints from '@/components/developer/docs/ApiReferenceDppEndpoints';
 import ApiReferenceQrEndpoints from '@/components/developer/docs/ApiReferenceQrEndpoints';
 import ApiReferenceComplianceEndpoints from '@/components/developer/docs/ApiReferenceComplianceEndpoints';
+import ApiReferenceTokenEndpoints from '@/components/developer/docs/ApiReferenceTokenEndpoints';
 
 export default function ApiReferencePage() {
   const exampleDppResponse = JSON.stringify(MOCK_DPPS[0], null, 2);
@@ -41,6 +42,39 @@ export default function ApiReferencePage() {
     }
   };
   const exampleQrValidationResponse = JSON.stringify(qrValidationResponseExample, null, 2);
+
+  const mintTokenRequest = JSON.stringify({
+    contractAddress: "0xABCDEF123456",
+    recipientAddress: "0x1234567890",
+    metadataUri: "ipfs://sample-metadata"
+  }, null, 2);
+
+  const mintTokenResponse = JSON.stringify({
+    tokenId: "1",
+    contractAddress: "0xABCDEF123456",
+    transactionHash: "0xMINTTX123"
+  }, null, 2);
+
+  const updateTokenRequest = JSON.stringify({
+    metadataUri: "ipfs://updated-metadata",
+    contractAddress: "0xABCDEF123456"
+  }, null, 2);
+
+  const updateTokenResponse = JSON.stringify({
+    tokenId: "1",
+    contractAddress: "0xABCDEF123456",
+    transactionHash: "0xUPDATETX456"
+  }, null, 2);
+
+  const tokenStatusResponse = JSON.stringify({
+    tokenId: "1",
+    contractAddress: "0xABCDEF123456",
+    ownerAddress: "0x1234567890",
+    mintedAt: new Date().toISOString(),
+    metadataUri: "ipfs://sample-metadata",
+    lastTransactionHash: "0xUPDATETX456",
+    status: "minted"
+  }, null, 2);
 
   const error401 = JSON.stringify({ error: { code: 401, message: "API key missing or invalid." } }, null, 2);
   const error404 = JSON.stringify({ error: { code: 404, message: "Resource not found." } }, { status: 404 }); 
@@ -271,6 +305,16 @@ export default function ApiReferencePage() {
         error400_update_dpp={error400_update_dpp}
         error400_patch_dpp={error400_patch_dpp}
         error400_lifecycle_event={error400_lifecycle_event}
+      />
+      <ApiReferenceTokenEndpoints
+        mintRequest={mintTokenRequest}
+        mintResponse={mintTokenResponse}
+        updateRequest={updateTokenRequest}
+        updateResponse={updateTokenResponse}
+        statusResponse={tokenStatusResponse}
+        error401={error401}
+        error404={error404}
+        error500={error500}
       />
       <ApiReferenceQrEndpoints
         exampleQrValidationResponse={exampleQrValidationResponse}

--- a/src/components/developer/docs/ApiReferenceTokenEndpoints.tsx
+++ b/src/components/developer/docs/ApiReferenceTokenEndpoints.tsx
@@ -1,0 +1,165 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { FileJson, Server } from "lucide-react";
+
+interface TokenEndpointsProps {
+  mintRequest: string;
+  mintResponse: string;
+  updateRequest: string;
+  updateResponse: string;
+  statusResponse: string;
+  error401: string;
+  error404: string;
+  error500: string;
+}
+
+export default function ApiReferenceTokenEndpoints({
+  mintRequest,
+  mintResponse,
+  updateRequest,
+  updateResponse,
+  statusResponse,
+  error401,
+  error404,
+  error500,
+}: TokenEndpointsProps) {
+  return (
+    <section id="token-endpoints" className="mt-8">
+      <h2 className="text-2xl font-semibold font-headline mt-8 mb-4 flex items-center">
+        <Server className="mr-3 h-6 w-6 text-primary" /> DPP Token Endpoints
+      </h2>
+
+      <Card className="shadow-lg mt-6">
+        <CardHeader>
+          <CardTitle className="text-lg">Mint DPP Token</CardTitle>
+          <CardDescription>
+            <span className="inline-flex items-center font-mono text-sm">
+              <Badge variant="outline" className="bg-green-100 text-green-700 border-green-300 mr-2 font-semibold">POST</Badge>
+              <code className="bg-muted px-1 py-0.5 rounded-sm">/token/mint/{{productId}}</code>
+            </span>
+            <br />
+            Mints a blockchain token representing the specified product passport.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <section>
+            <h4 className="font-semibold mb-1">Request Body (JSON)</h4>
+            <pre className="bg-muted p-3 rounded-md text-xs overflow-x-auto mt-2">
+              <code>{mintRequest}</code>
+            </pre>
+          </section>
+          <section>
+            <h4 className="font-semibold mb-1">Example Response (201 Created)</h4>
+            <details className="border rounded-md">
+              <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
+                <FileJson className="inline h-4 w-4 mr-1 align-middle" />Example JSON Response
+              </summary>
+              <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
+                <code>{mintResponse}</code>
+              </pre>
+            </details>
+          </section>
+          <section>
+            <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
+            <ul className="list-disc list-inside text-sm space-y-2">
+              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">401 Unauthorized</code>
+                <details className="border rounded-md mt-1">
+                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
+                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error401}</code></pre>
+                </details>
+              </li>
+              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">404 Not Found</code>
+                <details className="border rounded-md mt-1">
+                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
+                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error404}</code></pre>
+                </details>
+              </li>
+              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">500 Internal Server Error</code>
+                <details className="border rounded-md mt-1">
+                  <summary className="cursor-pointer p-1 bg-muted hover:bg-muted/80 text-xs ml-4">Example JSON</summary>
+                  <pre className="bg-muted/50 p-2 rounded-b-md text-xs overflow-x-auto ml-4"><code>{error500}</code></pre>
+                </details>
+              </li>
+            </ul>
+          </section>
+        </CardContent>
+      </Card>
+
+      <Card className="shadow-lg mt-6">
+        <CardHeader>
+          <CardTitle className="text-lg">Update Token Metadata</CardTitle>
+          <CardDescription>
+            <span className="inline-flex items-center font-mono text-sm">
+              <Badge variant="outline" className="bg-yellow-100 text-yellow-700 border-yellow-300 mr-2 font-semibold">PATCH</Badge>
+              <code className="bg-muted px-1 py-0.5 rounded-sm">/token/metadata/{{tokenId}}</code>
+            </span>
+            <br />
+            Updates the metadata URI stored on chain for a token.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <section>
+            <h4 className="font-semibold mb-1">Request Body (JSON)</h4>
+            <pre className="bg-muted p-3 rounded-md text-xs overflow-x-auto mt-2">
+              <code>{updateRequest}</code>
+            </pre>
+          </section>
+          <section>
+            <h4 className="font-semibold mb-1">Example Response (200 OK)</h4>
+            <details className="border rounded-md">
+              <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
+                <FileJson className="inline h-4 w-4 mr-1 align-middle" />Example JSON Response
+              </summary>
+              <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
+                <code>{updateResponse}</code>
+              </pre>
+            </details>
+          </section>
+          <section>
+            <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
+            <ul className="list-disc list-inside text-sm space-y-2">
+              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">401 Unauthorized</code></li>
+              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">404 Not Found</code></li>
+              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">500 Internal Server Error</code></li>
+            </ul>
+          </section>
+        </CardContent>
+      </Card>
+
+      <Card className="shadow-lg mt-6">
+        <CardHeader>
+          <CardTitle className="text-lg">Get Token On-Chain Status</CardTitle>
+          <CardDescription>
+            <span className="inline-flex items-center font-mono text-sm">
+              <Badge variant="outline" className="bg-sky-100 text-sky-700 border-sky-300 mr-2 font-semibold">GET</Badge>
+              <code className="bg-muted px-1 py-0.5 rounded-sm">/token/status/{{tokenId}}</code>
+            </span>
+            <br />
+            Retrieves blockchain status information for a token.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <section>
+            <h4 className="font-semibold mb-1">Example Response (200 OK)</h4>
+            <details className="border rounded-md">
+              <summary className="cursor-pointer p-2 bg-muted hover:bg-muted/80 text-sm">
+                <FileJson className="inline h-4 w-4 mr-1 align-middle" />Example JSON Response
+              </summary>
+              <pre className="bg-muted/50 p-3 rounded-b-md text-xs overflow-x-auto max-h-96">
+                <code>{statusResponse}</code>
+              </pre>
+            </details>
+          </section>
+          <section>
+            <h4 className="font-semibold mb-1 mt-3">Common Error Responses</h4>
+            <ul className="list-disc list-inside text-sm space-y-2">
+              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">401 Unauthorized</code></li>
+              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">404 Not Found</code></li>
+              <li><code className="bg-muted px-1 py-0.5 rounded-sm font-mono text-xs">500 Internal Server Error</code></li>
+            </ul>
+          </section>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add endpoints for minting tokens and checking on-chain status
- document token API in dev docs

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing type definitions)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684928bf4edc832ab659a7dafd6ee501